### PR TITLE
Fix user context handling in API handlers

### DIFF
--- a/internal/infrastructure/http/router.go
+++ b/internal/infrastructure/http/router.go
@@ -37,8 +37,8 @@ func NewServer(
 	// User ID will now be dynamically extracted from JWT in AuthMiddleware
 	// The fixedUserID passed to Sheep/Vaccine handlers is for demonstration before auth is fully implemented for every route.
 	// In production, SheepHandler and VaccineHandler would get user ID from context via middleware.
-	sheepHandler := handlers.NewSheepHandler(sheepService, "")       // Pass empty string, handler will get from context
-	vaccineHandler := handlers.NewVaccineHandler(vaccineService, "") // Pass empty string
+	sheepHandler := handlers.NewSheepHandler(sheepService)
+	vaccineHandler := handlers.NewVaccineHandler(vaccineService)
 
 	router := mux.NewRouter()
 	s := &Server{


### PR DESCRIPTION
## Summary
- obtain authenticated user ID in sheep and vaccine handlers
- update router to use new handler constructors

## Testing
- `go build ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6868d53d61a0832695430f6e70c3b856