### PR TITLE
Add simple Persian frontend

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>سامانه مدیریت گوسفندان هلشتاین</title>
+    <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>سامانه مدیریت گوسفندان هلشتاین</h1>
+        <div id="status" class="status">در حال بررسی ارتباط با سرور...</div>
+        <form id="loginForm" class="login-form">
+            <label>ایمیل
+                <input type="email" id="email" required>
+            </label>
+            <label>گذرواژه
+                <input type="password" id="password" required>
+            </label>
+            <button type="submit">ورود</button>
+        </form>
+        <div id="loginMessage" class="message"></div>
+    </div>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/front/main.js
+++ b/front/main.js
@@ -1,0 +1,37 @@
+const statusEl = document.getElementById('status');
+const loginForm = document.getElementById('loginForm');
+const loginMessage = document.getElementById('loginMessage');
+
+// Check connection to backend
+fetch('http://localhost:8080/')
+  .then(res => {
+    if (res.ok) {
+      statusEl.textContent = 'ارتباط با سرور برقرار است';
+    } else {
+      statusEl.textContent = 'عدم ارتباط با سرور';
+    }
+  })
+  .catch(() => {
+    statusEl.textContent = 'عدم ارتباط با سرور';
+  });
+
+loginForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  loginMessage.textContent = 'در حال ورود...';
+  try {
+    const res = await fetch('http://localhost:8080/api/v1/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: document.getElementById('email').value,
+        password: document.getElementById('password').value
+      })
+    });
+    if (!res.ok) throw new Error('خطا در ورود');
+    const data = await res.json();
+    localStorage.setItem('token', data.token);
+    loginMessage.textContent = 'ورود موفق';
+  } catch (err) {
+    loginMessage.textContent = 'ورود ناموفق';
+  }
+});

--- a/front/style.css
+++ b/front/style.css
@@ -1,0 +1,67 @@
+body {
+    font-family: 'Vazirmatn', sans-serif;
+    margin: 0;
+    padding: 0;
+    background: url('https://images.unsplash.com/photo-1461423576160-a119efac01f9?auto=format&fit=crop&w=1350&q=80') no-repeat center center fixed;
+    background-size: cover;
+    color: #333;
+}
+
+.container {
+    max-width: 400px;
+    margin: 50px auto;
+    background: rgba(255, 255, 255, 0.8);
+    padding: 20px;
+    border-radius: 8px;
+}
+
+h1 {
+    font-size: 1.4rem;
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+.status {
+    text-align: center;
+    margin-bottom: 15px;
+    font-size: 0.9rem;
+}
+
+.login-form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.login-form label {
+    display: flex;
+    flex-direction: column;
+    font-size: 0.9rem;
+}
+
+.login-form input {
+    padding: 6px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.login-form button {
+    padding: 8px;
+    background-color: #4CAF50;
+    border: none;
+    color: white;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.message {
+    margin-top: 10px;
+    text-align: center;
+    font-size: 0.9rem;
+}
+
+@media (max-width: 480px) {
+    .container {
+        margin: 20px;
+    }
+}


### PR DESCRIPTION
## Summary
- add `front` folder with simple Persian UI
- provide index page with login form
- style with Farsi font and sheep background
- JS to check backend connection and handle login

## Testing
- `go vet ./...`
- `go test ./...`
- `FIREBASE_CREDENTIALS_PATH=nonexistent go run cmd/api/main.go` *(fails: project id is required to access Firestore)*

------
https://chatgpt.com/codex/tasks/task_e_686e811b00488322a54d9d13109b9476