### PR TITLE
Extend UI with dashboard and reminder endpoint

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -92,7 +92,7 @@ func main() {
 	// --- 6. Initialize and Start HTTP Server (Presentation Layer) ---
 	// User ID for handlers will now come from context after authentication.
 	// No need to pass fixedUserID to handlers directly anymore.
-	server := http.NewServer(sheepService, vaccineService, authService, userService) // Pass auth and user services
+	server := http.NewServer(sheepService, vaccineService, authService, userService, reminderService) // Pass reminder service too
 	apiPort := os.Getenv("API_PORT")
 	if apiPort == "" {
 		apiPort = "8080" // Default port for API

--- a/front/dashboard.html
+++ b/front/dashboard.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>داشبورد - هلشتاین</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="#">هلشتاین</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav ms-auto">
+                <li class="nav-item"><a class="nav-link" href="dashboard.html">داشبورد</a></li>
+                <li class="nav-item"><a class="nav-link" href="sheep.html">گوسفندها</a></li>
+                <li class="nav-item"><a class="nav-link" href="vaccination.html">واکسیناسیون</a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+<main class="container pt-5 mt-4">
+    <div class="row g-3" id="statsCards">
+        <!-- Stats will be inserted here -->
+    </div>
+    <h2 class="mt-4">یادآورها</h2>
+    <div id="reminders" class="mt-3">
+        <!-- Reminder cards -->
+    </div>
+</main>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="main.js"></script>
+<script src="dashboard.js"></script>
+</body>
+</html>

--- a/front/dashboard.js
+++ b/front/dashboard.js
@@ -1,0 +1,53 @@
+const token = localStorage.getItem('token');
+if (!token) {
+    window.location.href = 'index.html';
+}
+
+const headers = { 'Authorization': `Bearer ${token}` };
+
+function loadStats() {
+    fetch(`${API_BASE}/sheep`, { headers })
+        .then(res => res.json())
+        .then(data => {
+            const total = data.length;
+            const pregnant = data.filter(s => s.breedingDate).length;
+            const stats = [
+                { label: 'تعداد کل', value: total, icon: 'bi bi-emoji-smile' },
+                { label: 'آبستن', value: pregnant, icon: 'bi bi-heart-fill' }
+            ];
+            const container = document.getElementById('statsCards');
+            stats.forEach(s => {
+                const div = document.createElement('div');
+                div.className = 'col-6 col-md-3';
+                div.innerHTML = `<div class="card text-center shadow-sm">
+                    <div class="card-body">
+                        <i class="${s.icon} fs-1 text-primary"></i>
+                        <h4 class="mt-2">${s.value}</h4>
+                        <p class="mb-0">${s.label}</p>
+                    </div>
+                </div>`;
+                container.appendChild(div);
+            });
+        });
+}
+
+function loadReminders() {
+    fetch(`${API_BASE}/reminders`, { headers })
+        .then(res => res.json())
+        .then(data => {
+            const container = document.getElementById('reminders');
+            if (!data.length) {
+                container.textContent = 'یادآوری برای نمایش وجود ندارد';
+                return;
+            }
+            data.forEach(r => {
+                const alert = document.createElement('div');
+                alert.className = 'alert alert-warning d-flex align-items-center';
+                alert.innerHTML = `<i class="bi bi-bell-fill me-2"></i><div>${r.message}</div>`;
+                container.appendChild(alert);
+            });
+        });
+}
+
+loadStats();
+loadReminders();

--- a/front/index.html
+++ b/front/index.html
@@ -6,6 +6,7 @@
     <title>سامانه مدیریت گوسفندان هلشتاین</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
     <link rel="stylesheet" href="style.css">
 </head>
 <body class="d-flex flex-column min-vh-100">

--- a/front/main.js
+++ b/front/main.js
@@ -1,6 +1,7 @@
 const statusEl = document.getElementById('status');
 const loginForm = document.getElementById('loginForm');
 const loginMessage = document.getElementById('loginMessage');
+const API_BASE = 'http://localhost:8080/api/v1';
 
 // Check connection to backend
 fetch('http://localhost:8080/')
@@ -19,7 +20,7 @@ loginForm.addEventListener('submit', async (e) => {
   e.preventDefault();
   loginMessage.textContent = 'در حال ورود...';
   try {
-    const res = await fetch('http://localhost:8080/api/v1/login', {
+    const res = await fetch(`${API_BASE}/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -31,6 +32,7 @@ loginForm.addEventListener('submit', async (e) => {
     const data = await res.json();
     localStorage.setItem('token', data.token);
     loginMessage.textContent = 'ورود موفق';
+    window.location.href = 'dashboard.html';
   } catch (err) {
     loginMessage.textContent = 'ورود ناموفق';
   }

--- a/front/sheep.html
+++ b/front/sheep.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>مدیریت گوسفندها</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="dashboard.html">هلشتاین</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav ms-auto">
+                <li class="nav-item"><a class="nav-link" href="dashboard.html">داشبورد</a></li>
+                <li class="nav-item"><a class="nav-link active" href="sheep.html">گوسفندها</a></li>
+                <li class="nav-item"><a class="nav-link" href="vaccination.html">واکسیناسیون</a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+<main class="container pt-5 mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="m-0">لیست گوسفندان</h2>
+        <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#sheepModal"><i class="bi bi-plus-circle"></i> افزودن</button>
+    </div>
+    <table class="table table-bordered table-hover" id="sheepTable">
+        <thead class="table-light">
+            <tr>
+                <th>نام</th>
+                <th>سن</th>
+                <th>جنس</th>
+                <th>کد گوش</th>
+                <th>وضعیت</th>
+                <th>عملیات</th>
+            </tr>
+        </thead>
+        <tbody>
+            <!-- Rows inserted here -->
+        </tbody>
+    </table>
+</main>
+<!-- Sheep Modal -->
+<div class="modal fade" id="sheepModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="sheepModalLabel">گوسفند</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="sheepForm">
+          <div class="mb-3">
+            <label class="form-label">نام</label>
+            <input type="text" class="form-control" id="sheepName" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">جنسیت</label>
+            <select id="sheepGender" class="form-select">
+              <option value="male">نر</option>
+              <option value="female">ماده</option>
+            </select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">تاریخ تولد</label>
+            <input type="date" class="form-control" id="sheepDob" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">کد گوش</label>
+            <input type="text" class="form-control" id="sheepTag" required>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">انصراف</button>
+        <button type="submit" form="sheepForm" class="btn btn-primary">ذخیره</button>
+      </div>
+    </div>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="main.js"></script>
+<script src="sheep.js"></script>
+</body>
+</html>

--- a/front/sheep.js
+++ b/front/sheep.js
@@ -1,0 +1,71 @@
+const tokenSheep = localStorage.getItem('token');
+if (!tokenSheep) {
+    window.location.href = 'index.html';
+}
+const headersSheep = { 'Authorization': `Bearer ${tokenSheep}`, 'Content-Type': 'application/json' };
+
+const tableBody = document.querySelector('#sheepTable tbody');
+const form = document.getElementById('sheepForm');
+let editingId = null;
+
+function loadSheep() {
+    fetch(`${API_BASE}/sheep`, { headers: headersSheep })
+        .then(res => res.json())
+        .then(list => {
+            tableBody.innerHTML = '';
+            list.forEach(s => {
+                const tr = document.createElement('tr');
+                const age = new Date().getFullYear() - new Date(s.dateOfBirth).getFullYear();
+                tr.innerHTML = `
+                    <td>${s.name}</td>
+                    <td>${age}</td>
+                    <td>${s.gender === 'male' ? 'نر' : 'ماده'}</td>
+                    <td>${s.id}</td>
+                    <td>${s.breedingDate ? 'آبستن' : '-'}</td>
+                    <td>
+                        <button class="btn btn-sm btn-primary me-1" onclick="editSheep('${s.id}')"><i class="bi bi-pencil"></i></button>
+                        <button class="btn btn-sm btn-danger" onclick="deleteSheep('${s.id}')"><i class="bi bi-trash"></i></button>
+                    </td>`;
+                tableBody.appendChild(tr);
+            });
+        });
+}
+
+window.editSheep = function(id) {
+    fetch(`${API_BASE}/sheep/${id}`, { headers: headersSheep })
+        .then(res => res.json())
+        .then(s => {
+            editingId = id;
+            document.getElementById('sheepName').value = s.name;
+            document.getElementById('sheepGender').value = s.gender;
+            document.getElementById('sheepDob').value = s.dateOfBirth.split('T')[0];
+            document.getElementById('sheepTag').value = s.id;
+            new bootstrap.Modal(document.getElementById('sheepModal')).show();
+        });
+}
+
+window.deleteSheep = function(id) {
+    if (!confirm('حذف شود؟')) return;
+    fetch(`${API_BASE}/sheep/${id}`, { method: 'DELETE', headers: headersSheep })
+        .then(() => loadSheep());
+}
+
+form.addEventListener('submit', e => {
+    e.preventDefault();
+    const body = JSON.stringify({
+        name: document.getElementById('sheepName').value,
+        gender: document.getElementById('sheepGender').value,
+        dateOfBirth: document.getElementById('sheepDob').value
+    });
+    const method = editingId ? 'PUT' : 'POST';
+    const url = editingId ? `${API_BASE}/sheep/${editingId}` : `${API_BASE}/sheep`;
+    fetch(url, { method, headers: headersSheep, body })
+        .then(() => {
+            bootstrap.Modal.getInstance(document.getElementById('sheepModal')).hide();
+            editingId = null;
+            form.reset();
+            loadSheep();
+        });
+});
+
+loadSheep();

--- a/front/style.css
+++ b/front/style.css
@@ -2,6 +2,10 @@ body {
     font-family: 'Vazirmatn', sans-serif;
     background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
     min-height: 100vh;
+    background-image: url('https://cdn.jsdelivr.net/gh/twitter/twemoji/assets/svg/1f411.svg');
+    background-repeat: no-repeat;
+    background-position: bottom left;
+    background-size: 120px;
 }
 
 .hero-space {
@@ -21,4 +25,12 @@ body {
 
 .btn-primary:hover {
     transform: scale(1.05);
+}
+
+.navbar-brand {
+    font-weight: bold;
+}
+
+.table-hover tbody tr:hover {
+    background-color: #f0f8ff;
 }

--- a/front/vaccination.html
+++ b/front/vaccination.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>واکسیناسیون</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="dashboard.html">هلشتاین</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav ms-auto">
+                <li class="nav-item"><a class="nav-link" href="dashboard.html">داشبورد</a></li>
+                <li class="nav-item"><a class="nav-link" href="sheep.html">گوسفندها</a></li>
+                <li class="nav-item"><a class="nav-link active" href="vaccination.html">واکسیناسیون</a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+<main class="container pt-5 mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="m-0">سوابق واکسن</h2>
+        <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#vaccineModal"><i class="bi bi-plus-circle"></i> افزودن</button>
+    </div>
+    <table class="table table-bordered table-hover" id="vaccineTable">
+        <thead class="table-light">
+            <tr>
+                <th>گوسفند</th>
+                <th>واکسن</th>
+                <th>تاریخ</th>
+                <th>دوز بعدی</th>
+                <th>یادداشت</th>
+            </tr>
+        </thead>
+        <tbody>
+            <!-- Rows inserted here -->
+        </tbody>
+    </table>
+</main>
+<div class="modal fade" id="vaccineModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">افزودن واکسن</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="vaccineForm">
+          <div class="mb-3">
+            <label class="form-label">گوسفند</label>
+            <select id="vaccineSheep" class="form-select"></select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">نام واکسن</label>
+            <input type="text" class="form-control" id="vaccineName" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">تاریخ</label>
+            <input type="date" class="form-control" id="vaccineDate" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">دوز بعدی</label>
+            <input type="date" class="form-control" id="vaccineNext">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">یادداشت</label>
+            <textarea class="form-control" id="vaccineNote"></textarea>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">انصراف</button>
+        <button type="submit" form="vaccineForm" class="btn btn-primary">ذخیره</button>
+      </div>
+    </div>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="main.js"></script>
+<script src="vaccine.js"></script>
+</body>
+</html>

--- a/front/vaccine.js
+++ b/front/vaccine.js
@@ -1,0 +1,40 @@
+const tokenVax = localStorage.getItem('token');
+if (!tokenVax) {
+    window.location.href = 'index.html';
+}
+const headersVax = { 'Authorization': `Bearer ${tokenVax}`, 'Content-Type': 'application/json' };
+
+const tableVax = document.querySelector('#vaccineTable tbody');
+const formVax = document.getElementById('vaccineForm');
+
+function loadVaccines() {
+    fetch(`${API_BASE}/vaccines`, { headers: headersVax })
+        .then(res => res.json())
+        .then(list => {
+            tableVax.innerHTML = '';
+            list.forEach(v => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `<td>${v.sheepID}</td><td>${v.name}</td><td>${v.date ? v.date.split('T')[0] : ''}</td><td>${v.nextDose ? v.nextDose.split('T')[0] : ''}</td><td>${v.description || ''}</td>`;
+                tableVax.appendChild(tr);
+            });
+        });
+}
+
+formVax.addEventListener('submit', e => {
+    e.preventDefault();
+    const body = JSON.stringify({
+        name: document.getElementById('vaccineName').value,
+        sheepID: document.getElementById('vaccineSheep').value,
+        date: document.getElementById('vaccineDate').value,
+        nextDose: document.getElementById('vaccineNext').value,
+        description: document.getElementById('vaccineNote').value
+    });
+    fetch(`${API_BASE}/vaccines`, { method: 'POST', headers: headersVax, body })
+        .then(() => {
+            bootstrap.Modal.getInstance(document.getElementById('vaccineModal')).hide();
+            formVax.reset();
+            loadVaccines();
+        });
+});
+
+loadVaccines();

--- a/internal/infrastructure/http/handlers/reminder_handler.go
+++ b/internal/infrastructure/http/handlers/reminder_handler.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"sheep_farm_backend_go/internal/application/services"
+	"sheep_farm_backend_go/internal/infrastructure/http/middleware"
+)
+
+// ReminderHandler provides reminder-related endpoints.
+type ReminderHandler struct {
+	reminderService *services.ReminderService
+}
+
+// NewReminderHandler creates a ReminderHandler.
+func NewReminderHandler(reminderService *services.ReminderService) *ReminderHandler {
+	return &ReminderHandler{reminderService: reminderService}
+}
+
+// GetReminders calculates reminders for the authenticated user.
+func (h *ReminderHandler) GetReminders(w http.ResponseWriter, r *http.Request) {
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	reminders, err := h.reminderService.CalculateAndSendReminders(r.Context(), userID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(reminders)
+}


### PR DESCRIPTION
## Summary
- redesign frontend with Bootstrap 5 dashboard, sheep and vaccine pages
- implement login redirect and common API base URL
- add reminder handler and route for fetching reminders
- wire reminder service into HTTP server

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686e9cd697108322ad0fb7f99d2873d0