### PR TITLE
Add lambing and vaccination service

### DIFF
--- a/internal/application/ports/repository.go
+++ b/internal/application/ports/repository.go
@@ -23,3 +23,10 @@ type VaccineRepository interface {
 	UpdateVaccine(ctx context.Context, vaccine *domain.Vaccine) error
 	DeleteVaccine(ctx context.Context, userID, vaccineID string) error
 }
+
+// VaccinationRepository defines operations for vaccination records.
+type VaccinationRepository interface {
+	CreateVaccination(ctx context.Context, userID, sheepID string, v domain.Vaccination) error
+	GetVaccinations(ctx context.Context, userID, sheepID string) ([]domain.Vaccination, error)
+	DeleteVaccination(ctx context.Context, userID, sheepID string, index int) error
+}

--- a/internal/application/services/reminder_service.go
+++ b/internal/application/services/reminder_service.go
@@ -47,20 +47,6 @@ func (s *ReminderService) CalculateAndSendReminders(ctx context.Context, userID 
 	now := time.Now()
 
 	for _, sheep := range sheepList {
-		// Lambing reminder (approx. 5 months after breeding)
-		if sheep.BreedingDate != nil {
-			lambingDate := sheep.BreedingDate.AddDate(0, 5, 0)
-			if lambingDate.After(now) && lambingDate.Before(now.AddDate(0, 1, 0)) { // Remind within next month
-				upcomingReminders = append(upcomingReminders, domain.Reminder{
-					Type:        domain.ReminderTypeLambing,
-					SheepID:     sheep.ID,
-					SheepName:   sheep.Name,
-					DueDate:     lambingDate,
-					Message:     fmt.Sprintf("زمان تقریبی زایمان گوسفند %s در تاریخ %s است.", sheep.Name, toPersianDate(lambingDate)),
-					OwnerUserID: userID,
-				})
-			}
-		}
 
 		// Shearing reminder (e.g., annually from last shearing)
 		if sheep.LastShearingDate != nil {
@@ -69,9 +55,9 @@ func (s *ReminderService) CalculateAndSendReminders(ctx context.Context, userID 
 				upcomingReminders = append(upcomingReminders, domain.Reminder{
 					Type:        domain.ReminderTypeShearing,
 					SheepID:     sheep.ID,
-					SheepName:   sheep.Name,
+					SheepName:   sheep.EarNumber1,
 					DueDate:     nextShearingDate,
-					Message:     fmt.Sprintf("زمان پشم‌چینی گوسفند %s در تاریخ %s نزدیک است.", sheep.Name, toPersianDate(nextShearingDate)),
+					Message:     fmt.Sprintf("زمان پشم‌چینی گوسفند %s در تاریخ %s نزدیک است.", sheep.EarNumber1, toPersianDate(nextShearingDate)),
 					OwnerUserID: userID,
 				})
 			}
@@ -84,9 +70,9 @@ func (s *ReminderService) CalculateAndSendReminders(ctx context.Context, userID 
 				upcomingReminders = append(upcomingReminders, domain.Reminder{
 					Type:        domain.ReminderTypeHoofTrim,
 					SheepID:     sheep.ID,
-					SheepName:   sheep.Name,
+					SheepName:   sheep.EarNumber1,
 					DueDate:     nextHoofTrimDate,
-					Message:     fmt.Sprintf("زمان سم‌چینی گوسفند %s در تاریخ %s نزدیک است.", sheep.Name, toPersianDate(nextHoofTrimDate)),
+					Message:     fmt.Sprintf("زمان سم‌چینی گوسفند %s در تاریخ %s نزدیک است.", sheep.EarNumber1, toPersianDate(nextHoofTrimDate)),
 					OwnerUserID: userID,
 				})
 			}
@@ -94,16 +80,16 @@ func (s *ReminderService) CalculateAndSendReminders(ctx context.Context, userID 
 
 		// Vaccination reminders based on intervalMonths
 		for _, vax := range sheep.Vaccinations {
-			if vaxDef, ok := vaccineMap[vax.VaccineID]; ok {
+			if vaxDef, ok := vaccineMap[vax.Vaccine]; ok {
 				nextVaccinationDate := vax.Date.AddDate(0, vaxDef.IntervalMonths, 0)
 				if nextVaccinationDate.After(now) && nextVaccinationDate.Before(now.AddDate(0, 1, 0)) { // Remind within next month
 					upcomingReminders = append(upcomingReminders, domain.Reminder{
 						Type:        domain.ReminderTypeVaccination,
 						SheepID:     sheep.ID,
-						SheepName:   sheep.Name,
+						SheepName:   sheep.EarNumber1,
 						VaccineName: vaxDef.Name,
 						DueDate:     nextVaccinationDate,
-						Message:     fmt.Sprintf("زمان واکسن %s برای گوسفند %s در تاریخ %s نزدیک است.", vaxDef.Name, sheep.Name, toPersianDate(nextVaccinationDate)),
+						Message:     fmt.Sprintf("زمان واکسن %s برای گوسفند %s در تاریخ %s نزدیک است.", vaxDef.Name, sheep.EarNumber1, toPersianDate(nextVaccinationDate)),
 						OwnerUserID: userID,
 					})
 				}

--- a/internal/application/services/vaccination_service.go
+++ b/internal/application/services/vaccination_service.go
@@ -1,0 +1,28 @@
+package services
+
+import (
+	"context"
+	"sheep_farm_backend_go/internal/application/ports"
+	"sheep_farm_backend_go/internal/domain"
+)
+
+// VaccinationService provides operations on vaccination records.
+type VaccinationService struct {
+	repo ports.VaccinationRepository
+}
+
+func NewVaccinationService(repo ports.VaccinationRepository) *VaccinationService {
+	return &VaccinationService{repo: repo}
+}
+
+func (s *VaccinationService) AddVaccination(ctx context.Context, userID, sheepID string, v domain.Vaccination) error {
+	return s.repo.CreateVaccination(ctx, userID, sheepID, v)
+}
+
+func (s *VaccinationService) ListVaccinations(ctx context.Context, userID, sheepID string) ([]domain.Vaccination, error) {
+	return s.repo.GetVaccinations(ctx, userID, sheepID)
+}
+
+func (s *VaccinationService) DeleteVaccination(ctx context.Context, userID, sheepID string, index int) error {
+	return s.repo.DeleteVaccination(ctx, userID, sheepID, index)
+}

--- a/internal/domain/lambing.go
+++ b/internal/domain/lambing.go
@@ -1,0 +1,11 @@
+package domain
+
+import "time"
+
+// Lambing represents a lambing event for a sheep.
+type Lambing struct {
+	Date    time.Time `json:"date" firestore:"date"`
+	NumBorn int       `json:"numBorn" firestore:"numBorn"`
+	Sexes   []string  `json:"sexes" firestore:"sexes"`
+	NumDead int       `json:"numDead" firestore:"numDead"`
+}

--- a/internal/domain/sheep.go
+++ b/internal/domain/sheep.go
@@ -4,17 +4,22 @@ import "time"
 
 // Sheep represents a sheep entity in the domain.
 type Sheep struct {
-	ID               string        `json:"id,omitempty" firestore:"id,omitempty"` // omitempty: don't include if empty
-	Name             string        `json:"name" firestore:"name"`
-	Gender           string        `json:"gender" firestore:"gender"` // "male" or "female"
+	ID               string        `json:"id,omitempty" firestore:"id,omitempty"`
+	EarNumber1       string        `json:"earNumber1" firestore:"earNumber1"`
+	EarNumber2       string        `json:"earNumber2,omitempty" firestore:"earNumber2,omitempty"`
+	EarNumber3       string        `json:"earNumber3,omitempty" firestore:"earNumber3,omitempty"`
+	NeckNumber       *string       `json:"neckNumber,omitempty" firestore:"neckNumber,omitempty"`
+	FatherGen        string        `json:"fatherGen,omitempty" firestore:"fatherGen,omitempty"`
+	BirthWeight      float64       `json:"birthWeight,omitempty" firestore:"birthWeight,omitempty"`
+	Gender           string        `json:"gender" firestore:"gender"`
 	DateOfBirth      time.Time     `json:"dateOfBirth" firestore:"dateOfBirth"`
-	BreedingDate     *time.Time    `json:"breedingDate,omitempty" firestore:"breedingDate,omitempty"` // Pointer for nullable field
 	LastShearingDate *time.Time    `json:"lastShearingDate,omitempty" firestore:"lastShearingDate,omitempty"`
 	LastHoofTrimDate *time.Time    `json:"lastHoofTrimDate,omitempty" firestore:"lastHoofTrimDate,omitempty"`
 	PhotoURL         string        `json:"photoUrl,omitempty" firestore:"photoUrl,omitempty"`
+	Lambings         []Lambing     `json:"lambings" firestore:"lambings"`
 	Vaccinations     []Vaccination `json:"vaccinations" firestore:"vaccinations"`
 	Treatments       []Treatment   `json:"treatments" firestore:"treatments"`
-	OwnerUserID      string        `json:"ownerUserId" firestore:"ownerUserId"` // To link sheep to a user
+	OwnerUserID      string        `json:"ownerUserId" firestore:"ownerUserId"`
 	CreatedAt        time.Time     `json:"createdAt" firestore:"createdAt"`
 	UpdatedAt        time.Time     `json:"updatedAt" firestore:"updatedAt"`
 }

--- a/internal/domain/treatment.go
+++ b/internal/domain/treatment.go
@@ -4,6 +4,7 @@ import "time"
 
 // Treatment represents a treatment record for a sheep.
 type Treatment struct {
-	Date        time.Time `json:"date" firestore:"date"`
-	Description string    `json:"description" firestore:"description"` // Details of the treatment
+	Date               time.Time `json:"date" firestore:"date"`
+	DiseaseDescription string    `json:"diseaseDescription" firestore:"diseaseDescription"`
+	TreatDescription   string    `json:"treatDescription" firestore:"treatDescription"`
 }

--- a/internal/domain/vaccine.go
+++ b/internal/domain/vaccine.go
@@ -4,9 +4,10 @@ import "time"
 
 // Vaccination represents a vaccine record for a sheep.
 type Vaccination struct {
-	VaccineID   string    `json:"vaccineId" firestore:"vaccineId"` // Reference to a defined Vaccine
 	Date        time.Time `json:"date" firestore:"date"`
-	Description string    `json:"description,omitempty" firestore:"description,omitempty"` // Optional notes
+	Vaccine     string    `json:"vaccine" firestore:"vaccine"`
+	Vaccinator  string    `json:"vaccinator" firestore:"vaccinator"`
+	Description string    `json:"description,omitempty" firestore:"description,omitempty"`
 }
 
 // Vaccine represents a type of vaccine defined by the user.

--- a/internal/infrastructure/http/handlers/sheep_handler.go
+++ b/internal/infrastructure/http/handlers/sheep_handler.go
@@ -128,23 +128,29 @@ func (h *SheepHandler) UpdateSheep(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Apply updates from DTO to domain entity
-	if req.Name != nil {
-		existingSheep.Name = *req.Name
+	if req.EarNumber1 != nil {
+		existingSheep.EarNumber1 = *req.EarNumber1
+	}
+	if req.EarNumber2 != nil {
+		existingSheep.EarNumber2 = *req.EarNumber2
+	}
+	if req.EarNumber3 != nil {
+		existingSheep.EarNumber3 = *req.EarNumber3
+	}
+	if req.NeckNumber != nil {
+		existingSheep.NeckNumber = *req.NeckNumber
+	}
+	if req.FatherGen != nil {
+		existingSheep.FatherGen = *req.FatherGen
+	}
+	if req.BirthWeight != nil {
+		existingSheep.BirthWeight = *req.BirthWeight
 	}
 	if req.Gender != nil {
 		existingSheep.Gender = *req.Gender
 	}
 	if req.DateOfBirth != nil {
 		existingSheep.DateOfBirth = time.Time(*req.DateOfBirth)
-	}
-	// Handle nullable pointer to pointer for dates. If `nil` means no change, `&DateOnly(time.Time{})` means set to null.
-	if req.BreedingDate != nil {
-		if *req.BreedingDate == nil { // Explicitly set to null
-			existingSheep.BreedingDate = nil
-		} else {
-			t := time.Time(**req.BreedingDate)
-			existingSheep.BreedingDate = &t
-		}
 	}
 	if req.LastShearingDate != nil {
 		if *req.LastShearingDate == nil {
@@ -169,8 +175,9 @@ func (h *SheepHandler) UpdateSheep(w http.ResponseWriter, r *http.Request) {
 		domainVaccinations := make([]domain.Vaccination, len(*req.Vaccinations))
 		for i, v := range *req.Vaccinations {
 			domainVaccinations[i] = domain.Vaccination{
-				VaccineID:   v.VaccineID,
 				Date:        time.Time(v.Date),
+				Vaccine:     v.Vaccine,
+				Vaccinator:  v.Vaccinator,
 				Description: v.Description,
 			}
 		}
@@ -180,11 +187,24 @@ func (h *SheepHandler) UpdateSheep(w http.ResponseWriter, r *http.Request) {
 		domainTreatments := make([]domain.Treatment, len(*req.Treatments))
 		for i, t := range *req.Treatments {
 			domainTreatments[i] = domain.Treatment{
-				Date:        time.Time(t.Date),
-				Description: t.Description,
+				Date:               time.Time(t.Date),
+				DiseaseDescription: t.DiseaseDescription,
+				TreatDescription:   t.TreatDescription,
 			}
 		}
 		existingSheep.Treatments = domainTreatments
+	}
+	if req.Lambings != nil {
+		domainLambings := make([]domain.Lambing, len(*req.Lambings))
+		for i, l := range *req.Lambings {
+			domainLambings[i] = domain.Lambing{
+				Date:    time.Time(l.Date),
+				NumBorn: l.NumBorn,
+				Sexes:   l.Sexes,
+				NumDead: l.NumDead,
+			}
+		}
+		existingSheep.Lambings = domainLambings
 	}
 
 	if err := h.sheepService.UpdateSheep(r.Context(), existingSheep); err != nil {


### PR DESCRIPTION
## Summary
- create Lambing entity
- expand Sheep model with ear numbers, birth weight, neck number, lambings, etc.
- update Vaccination and Treatment models
- add VaccinationRepository and VaccinationService
- implement vaccination persistence in Firestore
- update DTOs and handlers for new fields
- adjust reminder service for new sheep fields

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_687113e5fa7483229c0984a9683792a3