### PR TITLE
Enhance sheep states and filtering

### DIFF
--- a/internal/application/services/reminder_service.go
+++ b/internal/application/services/reminder_service.go
@@ -95,6 +95,21 @@ func (s *ReminderService) CalculateAndSendReminders(ctx context.Context, userID 
 				}
 			}
 		}
+
+		// Weaning reminder: 2 weeks after each lambing
+		for _, lamb := range sheep.Lambings {
+			weanDate := lamb.Date.AddDate(0, 0, 14)
+			if weanDate.After(now) && weanDate.Before(now.AddDate(0, 0, 7)) {
+				upcomingReminders = append(upcomingReminders, domain.Reminder{
+					Type:        domain.ReminderTypeWeaning,
+					SheepID:     sheep.ID,
+					SheepName:   sheep.EarNumber1,
+					DueDate:     weanDate,
+					Message:     fmt.Sprintf("زمان از شیر گرفتن بره های %s در تاریخ %s است.", sheep.EarNumber1, toPersianDate(weanDate)),
+					OwnerUserID: userID,
+				})
+			}
+		}
 	}
 
 	// Send notifications for all collected reminders

--- a/internal/application/services/sheep_service.go
+++ b/internal/application/services/sheep_service.go
@@ -38,6 +38,30 @@ func (s *SheepService) GetAllSheep(ctx context.Context, userID string) ([]domain
 	return s.repo.GetAllSheep(ctx, userID)
 }
 
+// FilterSheep retrieves sheep filtered by gender and age range (in days).
+func (s *SheepService) FilterSheep(ctx context.Context, userID string, gender *string, minAgeDays, maxAgeDays *int) ([]domain.Sheep, error) {
+	sheepList, err := s.repo.GetAllSheep(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	var result []domain.Sheep
+	now := time.Now()
+	for _, sh := range sheepList {
+		if gender != nil && sh.Gender != *gender {
+			continue
+		}
+		ageDays := int(now.Sub(sh.DateOfBirth).Hours() / 24)
+		if minAgeDays != nil && ageDays < *minAgeDays {
+			continue
+		}
+		if maxAgeDays != nil && ageDays > *maxAgeDays {
+			continue
+		}
+		result = append(result, sh)
+	}
+	return result, nil
+}
+
 // UpdateSheep updates an existing sheep.
 func (s *SheepService) UpdateSheep(ctx context.Context, sheep *domain.Sheep) error {
 	// Add business rules specific to updating

--- a/internal/domain/sheep.go
+++ b/internal/domain/sheep.go
@@ -2,24 +2,40 @@ package domain
 
 import "time"
 
+// Possible reproduction states for a sheep
+const (
+	ReproductionNormal    = "normal"
+	ReproductionPregnant  = "pregnant"
+	ReproductionPostBirth = "post_birth"
+)
+
+// Possible health states for a sheep
+const (
+	HealthHealthy        = "healthy"
+	HealthSick           = "sick"
+	HealthUnderTreatment = "under_treatment"
+)
+
 // Sheep represents a sheep entity in the domain.
 type Sheep struct {
-	ID               string        `json:"id,omitempty" firestore:"id,omitempty"`
-	EarNumber1       string        `json:"earNumber1" firestore:"earNumber1"`
-	EarNumber2       string        `json:"earNumber2,omitempty" firestore:"earNumber2,omitempty"`
-	EarNumber3       string        `json:"earNumber3,omitempty" firestore:"earNumber3,omitempty"`
-	NeckNumber       *string       `json:"neckNumber,omitempty" firestore:"neckNumber,omitempty"`
-	FatherGen        string        `json:"fatherGen,omitempty" firestore:"fatherGen,omitempty"`
-	BirthWeight      float64       `json:"birthWeight,omitempty" firestore:"birthWeight,omitempty"`
-	Gender           string        `json:"gender" firestore:"gender"`
-	DateOfBirth      time.Time     `json:"dateOfBirth" firestore:"dateOfBirth"`
-	LastShearingDate *time.Time    `json:"lastShearingDate,omitempty" firestore:"lastShearingDate,omitempty"`
-	LastHoofTrimDate *time.Time    `json:"lastHoofTrimDate,omitempty" firestore:"lastHoofTrimDate,omitempty"`
-	PhotoURL         string        `json:"photoUrl,omitempty" firestore:"photoUrl,omitempty"`
-	Lambings         []Lambing     `json:"lambings" firestore:"lambings"`
-	Vaccinations     []Vaccination `json:"vaccinations" firestore:"vaccinations"`
-	Treatments       []Treatment   `json:"treatments" firestore:"treatments"`
-	OwnerUserID      string        `json:"ownerUserId" firestore:"ownerUserId"`
-	CreatedAt        time.Time     `json:"createdAt" firestore:"createdAt"`
-	UpdatedAt        time.Time     `json:"updatedAt" firestore:"updatedAt"`
+	ID                string        `json:"id,omitempty" firestore:"id,omitempty"`
+	EarNumber1        string        `json:"earNumber1" firestore:"earNumber1"`
+	EarNumber2        string        `json:"earNumber2,omitempty" firestore:"earNumber2,omitempty"`
+	EarNumber3        string        `json:"earNumber3,omitempty" firestore:"earNumber3,omitempty"`
+	NeckNumber        *string       `json:"neckNumber,omitempty" firestore:"neckNumber,omitempty"`
+	FatherGen         string        `json:"fatherGen,omitempty" firestore:"fatherGen,omitempty"`
+	BirthWeight       float64       `json:"birthWeight,omitempty" firestore:"birthWeight,omitempty"`
+	Gender            string        `json:"gender" firestore:"gender"`
+	ReproductionState string        `json:"reproductionState" firestore:"reproductionState"`
+	HealthState       string        `json:"healthState" firestore:"healthState"`
+	DateOfBirth       time.Time     `json:"dateOfBirth" firestore:"dateOfBirth"`
+	LastShearingDate  *time.Time    `json:"lastShearingDate,omitempty" firestore:"lastShearingDate,omitempty"`
+	LastHoofTrimDate  *time.Time    `json:"lastHoofTrimDate,omitempty" firestore:"lastHoofTrimDate,omitempty"`
+	PhotoURL          string        `json:"photoUrl,omitempty" firestore:"photoUrl,omitempty"`
+	Lambings          []Lambing     `json:"lambings" firestore:"lambings"`
+	Vaccinations      []Vaccination `json:"vaccinations" firestore:"vaccinations"`
+	Treatments        []Treatment   `json:"treatments" firestore:"treatments"`
+	OwnerUserID       string        `json:"ownerUserId" firestore:"ownerUserId"`
+	CreatedAt         time.Time     `json:"createdAt" firestore:"createdAt"`
+	UpdatedAt         time.Time     `json:"updatedAt" firestore:"updatedAt"`
 }

--- a/internal/infrastructure/http/dto/sheep_dto.go
+++ b/internal/infrastructure/http/dto/sheep_dto.go
@@ -27,59 +27,65 @@ type TreatmentDTO struct {
 
 // CreateSheepRequest represents the data for creating a new sheep.
 type CreateSheepRequest struct {
-	EarNumber1       string           `json:"earNumber1"`
-	EarNumber2       string           `json:"earNumber2,omitempty"`
-	EarNumber3       string           `json:"earNumber3,omitempty"`
-	NeckNumber       *string          `json:"neckNumber,omitempty"`
-	FatherGen        string           `json:"fatherGen,omitempty"`
-	BirthWeight      float64          `json:"birthWeight,omitempty"`
-	Gender           string           `json:"gender"`
-	DateOfBirth      DateOnly         `json:"dateOfBirth"`
-	LastShearingDate *DateOnly        `json:"lastShearingDate,omitempty"`
-	LastHoofTrimDate *DateOnly        `json:"lastHoofTrimDate,omitempty"`
-	PhotoURL         string           `json:"photoUrl,omitempty"`
-	Lambings         []LambingDTO     `json:"lambings"`
-	Vaccinations     []VaccinationDTO `json:"vaccinations"`
-	Treatments       []TreatmentDTO   `json:"treatments"`
+	EarNumber1        string           `json:"earNumber1"`
+	EarNumber2        string           `json:"earNumber2,omitempty"`
+	EarNumber3        string           `json:"earNumber3,omitempty"`
+	NeckNumber        *string          `json:"neckNumber,omitempty"`
+	FatherGen         string           `json:"fatherGen,omitempty"`
+	BirthWeight       float64          `json:"birthWeight,omitempty"`
+	Gender            string           `json:"gender"`
+	ReproductionState string           `json:"reproductionState"`
+	HealthState       string           `json:"healthState"`
+	DateOfBirth       DateOnly         `json:"dateOfBirth"`
+	LastShearingDate  *DateOnly        `json:"lastShearingDate,omitempty"`
+	LastHoofTrimDate  *DateOnly        `json:"lastHoofTrimDate,omitempty"`
+	PhotoURL          string           `json:"photoUrl,omitempty"`
+	Lambings          []LambingDTO     `json:"lambings"`
+	Vaccinations      []VaccinationDTO `json:"vaccinations"`
+	Treatments        []TreatmentDTO   `json:"treatments"`
 }
 
 // UpdateSheepRequest represents the data for updating an existing sheep.
 type UpdateSheepRequest struct {
-	EarNumber1       *string           `json:"earNumber1,omitempty"`
-	EarNumber2       *string           `json:"earNumber2,omitempty"`
-	EarNumber3       *string           `json:"earNumber3,omitempty"`
-	NeckNumber       **string          `json:"neckNumber,omitempty"`
-	FatherGen        *string           `json:"fatherGen,omitempty"`
-	BirthWeight      *float64          `json:"birthWeight,omitempty"`
-	Gender           *string           `json:"gender,omitempty"`
-	DateOfBirth      *DateOnly         `json:"dateOfBirth,omitempty"`
-	LastShearingDate **DateOnly        `json:"lastShearingDate,omitempty"`
-	LastHoofTrimDate **DateOnly        `json:"lastHoofTrimDate,omitempty"`
-	PhotoURL         *string           `json:"photoUrl,omitempty"`
-	Lambings         *[]LambingDTO     `json:"lambings,omitempty"`
-	Vaccinations     *[]VaccinationDTO `json:"vaccinations,omitempty"`
-	Treatments       *[]TreatmentDTO   `json:"treatments,omitempty"`
+	EarNumber1        *string           `json:"earNumber1,omitempty"`
+	EarNumber2        *string           `json:"earNumber2,omitempty"`
+	EarNumber3        *string           `json:"earNumber3,omitempty"`
+	NeckNumber        **string          `json:"neckNumber,omitempty"`
+	FatherGen         *string           `json:"fatherGen,omitempty"`
+	BirthWeight       *float64          `json:"birthWeight,omitempty"`
+	Gender            *string           `json:"gender,omitempty"`
+	ReproductionState *string           `json:"reproductionState,omitempty"`
+	HealthState       *string           `json:"healthState,omitempty"`
+	DateOfBirth       *DateOnly         `json:"dateOfBirth,omitempty"`
+	LastShearingDate  **DateOnly        `json:"lastShearingDate,omitempty"`
+	LastHoofTrimDate  **DateOnly        `json:"lastHoofTrimDate,omitempty"`
+	PhotoURL          *string           `json:"photoUrl,omitempty"`
+	Lambings          *[]LambingDTO     `json:"lambings,omitempty"`
+	Vaccinations      *[]VaccinationDTO `json:"vaccinations,omitempty"`
+	Treatments        *[]TreatmentDTO   `json:"treatments,omitempty"`
 }
 
 // SheepResponse represents the sheep data returned in API responses.
 type SheepResponse struct {
-	ID               string           `json:"id"`
-	EarNumber1       string           `json:"earNumber1"`
-	EarNumber2       string           `json:"earNumber2,omitempty"`
-	EarNumber3       string           `json:"earNumber3,omitempty"`
-	NeckNumber       *string          `json:"neckNumber,omitempty"`
-	FatherGen        string           `json:"fatherGen,omitempty"`
-	BirthWeight      float64          `json:"birthWeight,omitempty"`
-	Gender           string           `json:"gender"`
-	DateOfBirth      DateOnly         `json:"dateOfBirth"`
-	LastShearingDate *DateOnly        `json:"lastShearingDate,omitempty"`
-	LastHoofTrimDate *DateOnly        `json:"lastHoofTrimDate,omitempty"`
-	PhotoURL         string           `json:"photoUrl,omitempty"`
-	Lambings         []LambingDTO     `json:"lambings"`
-	Vaccinations     []VaccinationDTO `json:"vaccinations"`
-	Treatments       []TreatmentDTO   `json:"treatments"`
-	CreatedAt        time.Time        `json:"createdAt"`
-	UpdatedAt        time.Time        `json:"updatedAt"`
+	ID                string           `json:"id"`
+	EarNumber1        string           `json:"earNumber1"`
+	EarNumber2        string           `json:"earNumber2,omitempty"`
+	EarNumber3        string           `json:"earNumber3,omitempty"`
+	NeckNumber        *string          `json:"neckNumber,omitempty"`
+	FatherGen         string           `json:"fatherGen,omitempty"`
+	BirthWeight       float64          `json:"birthWeight,omitempty"`
+	Gender            string           `json:"gender"`
+	ReproductionState string           `json:"reproductionState"`
+	HealthState       string           `json:"healthState"`
+	DateOfBirth       DateOnly         `json:"dateOfBirth"`
+	LastShearingDate  *DateOnly        `json:"lastShearingDate,omitempty"`
+	LastHoofTrimDate  *DateOnly        `json:"lastHoofTrimDate,omitempty"`
+	PhotoURL          string           `json:"photoUrl,omitempty"`
+	Lambings          []LambingDTO     `json:"lambings"`
+	Vaccinations      []VaccinationDTO `json:"vaccinations"`
+	Treatments        []TreatmentDTO   `json:"treatments"`
+	CreatedAt         time.Time        `json:"createdAt"`
+	UpdatedAt         time.Time        `json:"updatedAt"`
 }
 
 // ToDomain converts CreateSheepRequest to domain.Sheep
@@ -123,22 +129,31 @@ func (req *CreateSheepRequest) ToDomain(ownerUserID string) *domain.Sheep {
 		lastHoofTrimDate = req.LastHoofTrimDate.ToTimePtr()
 	}
 
+	if req.ReproductionState == "" {
+		req.ReproductionState = domain.ReproductionNormal
+	}
+	if req.HealthState == "" {
+		req.HealthState = domain.HealthHealthy
+	}
+
 	return &domain.Sheep{
-		EarNumber1:       req.EarNumber1,
-		EarNumber2:       req.EarNumber2,
-		EarNumber3:       req.EarNumber3,
-		NeckNumber:       req.NeckNumber,
-		FatherGen:        req.FatherGen,
-		BirthWeight:      req.BirthWeight,
-		Gender:           req.Gender,
-		DateOfBirth:      time.Time(req.DateOfBirth),
-		LastShearingDate: lastShearingDate,
-		LastHoofTrimDate: lastHoofTrimDate,
-		PhotoURL:         req.PhotoURL,
-		Lambings:         domainLambings,
-		Vaccinations:     domainVaccinations,
-		Treatments:       domainTreatments,
-		OwnerUserID:      ownerUserID,
+		EarNumber1:        req.EarNumber1,
+		EarNumber2:        req.EarNumber2,
+		EarNumber3:        req.EarNumber3,
+		NeckNumber:        req.NeckNumber,
+		FatherGen:         req.FatherGen,
+		BirthWeight:       req.BirthWeight,
+		Gender:            req.Gender,
+		ReproductionState: req.ReproductionState,
+		HealthState:       req.HealthState,
+		DateOfBirth:       time.Time(req.DateOfBirth),
+		LastShearingDate:  lastShearingDate,
+		LastHoofTrimDate:  lastHoofTrimDate,
+		PhotoURL:          req.PhotoURL,
+		Lambings:          domainLambings,
+		Vaccinations:      domainVaccinations,
+		Treatments:        domainTreatments,
+		OwnerUserID:       ownerUserID,
 	}
 }
 
@@ -174,23 +189,25 @@ func ToSheepResponse(s *domain.Sheep) *SheepResponse {
 	}
 
 	return &SheepResponse{
-		ID:               s.ID,
-		EarNumber1:       s.EarNumber1,
-		EarNumber2:       s.EarNumber2,
-		EarNumber3:       s.EarNumber3,
-		NeckNumber:       s.NeckNumber,
-		FatherGen:        s.FatherGen,
-		BirthWeight:      s.BirthWeight,
-		Gender:           s.Gender,
-		DateOfBirth:      DateOnly(s.DateOfBirth),
-		LastShearingDate: FromTimePtrPtr(s.LastShearingDate),
-		LastHoofTrimDate: FromTimePtrPtr(s.LastHoofTrimDate),
-		PhotoURL:         s.PhotoURL,
-		Lambings:         responseLambings,
-		Vaccinations:     responseVaccinations,
-		Treatments:       responseTreatments,
-		CreatedAt:        s.CreatedAt,
-		UpdatedAt:        s.UpdatedAt,
+		ID:                s.ID,
+		EarNumber1:        s.EarNumber1,
+		EarNumber2:        s.EarNumber2,
+		EarNumber3:        s.EarNumber3,
+		NeckNumber:        s.NeckNumber,
+		FatherGen:         s.FatherGen,
+		BirthWeight:       s.BirthWeight,
+		Gender:            s.Gender,
+		ReproductionState: s.ReproductionState,
+		HealthState:       s.HealthState,
+		DateOfBirth:       DateOnly(s.DateOfBirth),
+		LastShearingDate:  FromTimePtrPtr(s.LastShearingDate),
+		LastHoofTrimDate:  FromTimePtrPtr(s.LastHoofTrimDate),
+		PhotoURL:          s.PhotoURL,
+		Lambings:          responseLambings,
+		Vaccinations:      responseVaccinations,
+		Treatments:        responseTreatments,
+		CreatedAt:         s.CreatedAt,
+		UpdatedAt:         s.UpdatedAt,
 	}
 }
 

--- a/internal/infrastructure/persistence/firestore_repository.go
+++ b/internal/infrastructure/persistence/firestore_repository.go
@@ -96,21 +96,23 @@ func (r *FirestoreRepository) UpdateSheep(ctx context.Context, sheep *domain.She
 	// Use Map to allow partial updates with firestore.Set(ctx, map, firestore.MergeAll)
 	// Or define custom struct for updates. For simplicity, we'll update all fields from the sheep struct.
 	updateMap := map[string]interface{}{
-		"earNumber1":       sheep.EarNumber1,
-		"earNumber2":       sheep.EarNumber2,
-		"earNumber3":       sheep.EarNumber3,
-		"neckNumber":       sheep.NeckNumber,
-		"fatherGen":        sheep.FatherGen,
-		"birthWeight":      sheep.BirthWeight,
-		"gender":           sheep.Gender,
-		"dateOfBirth":      sheep.DateOfBirth,
-		"lastShearingDate": sheep.LastShearingDate,
-		"lastHoofTrimDate": sheep.LastHoofTrimDate,
-		"photoUrl":         sheep.PhotoURL,
-		"lambings":         sheep.Lambings,
-		"vaccinations":     sheep.Vaccinations,
-		"treatments":       sheep.Treatments,
-		"updatedAt":        time.Now(),
+		"earNumber1":        sheep.EarNumber1,
+		"earNumber2":        sheep.EarNumber2,
+		"earNumber3":        sheep.EarNumber3,
+		"neckNumber":        sheep.NeckNumber,
+		"fatherGen":         sheep.FatherGen,
+		"birthWeight":       sheep.BirthWeight,
+		"gender":            sheep.Gender,
+		"reproductionState": sheep.ReproductionState,
+		"healthState":       sheep.HealthState,
+		"dateOfBirth":       sheep.DateOfBirth,
+		"lastShearingDate":  sheep.LastShearingDate,
+		"lastHoofTrimDate":  sheep.LastHoofTrimDate,
+		"photoUrl":          sheep.PhotoURL,
+		"lambings":          sheep.Lambings,
+		"vaccinations":      sheep.Vaccinations,
+		"treatments":        sheep.Treatments,
+		"updatedAt":         time.Now(),
 	}
 
 	_, err := r.getUserCollection(sheep.OwnerUserID, "sheep").Doc(sheep.ID).Set(ctx, updateMap, firestore.MergeAll)


### PR DESCRIPTION
## Summary
- add reproduction and health states to sheep model
- extend DTOs and handlers for new states
- support sheep filtering by gender and age range
- store new fields in Firestore
- issue weaning reminders two weeks after lambing

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68712684fb888322bd405f3cd64199fe