### PR TITLE
Add endpoints for vaccination and treatment

### DIFF
--- a/front/dashboard.js
+++ b/front/dashboard.js
@@ -10,10 +10,23 @@ function loadStats() {
         .then(res => res.json())
         .then(data => {
             const total = data.length;
-            const pregnant = data.filter(s => s.breedingDate).length;
+            const pregnant = data.filter(s => s.reproductionState === 'pregnant').length;
+            const sick = data.filter(s => s.healthState === 'sick').length;
+            const treated = data.filter(s => s.healthState === 'under_treatment').length;
+            let birthsThisMonth = 0;
+            const now = new Date();
+            data.forEach(s => {
+                (s.lambings || []).forEach(l => {
+                    const d = new Date(l.date);
+                    if(d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear()) birthsThisMonth += l.numBorn;
+                });
+            });
             const stats = [
                 { label: 'تعداد کل', value: total, icon: 'bi bi-emoji-smile' },
-                { label: 'آبستن', value: pregnant, icon: 'bi bi-heart-fill' }
+                { label: 'آبستن', value: pregnant, icon: 'bi bi-heart-fill' },
+                { label: 'متولد این ماه', value: birthsThisMonth, icon: 'bi bi-baby' },
+                { label: 'بیمار', value: sick, icon: 'bi bi-emoji-frown' },
+                { label: 'تحت درمان', value: treated, icon: 'bi bi-hospital' }
             ];
             const container = document.getElementById('statsCards');
             stats.forEach(s => {
@@ -40,11 +53,24 @@ function loadReminders() {
                 container.textContent = 'یادآوری برای نمایش وجود ندارد';
                 return;
             }
+            const groups = {};
             data.forEach(r => {
-                const alert = document.createElement('div');
-                alert.className = 'alert alert-warning d-flex align-items-center';
-                alert.innerHTML = `<i class="bi bi-bell-fill me-2"></i><div>${r.message}</div>`;
-                container.appendChild(alert);
+                if (!groups[r.type]) groups[r.type] = [];
+                groups[r.type].push(r.message);
+            });
+            Object.keys(groups).forEach(k => {
+                const card = document.createElement('div');
+                card.className = 'card mb-2';
+                const body = document.createElement('div');
+                body.className = 'card-body';
+                body.innerHTML = `<strong>${k}</strong><ul class="mb-0"></ul>`;
+                groups[k].forEach(m => {
+                    const li = document.createElement('li');
+                    li.textContent = m;
+                    body.querySelector('ul').appendChild(li);
+                });
+                card.appendChild(body);
+                container.appendChild(card);
             });
         });
 }

--- a/front/sheep.html
+++ b/front/sheep.html
@@ -20,7 +20,9 @@
             <ul class="navbar-nav ms-auto">
                 <li class="nav-item"><a class="nav-link" href="dashboard.html">داشبورد</a></li>
                 <li class="nav-item"><a class="nav-link active" href="sheep.html">گوسفندها</a></li>
-                <li class="nav-item"><a class="nav-link" href="vaccination.html">واکسیناسیون</a></li>
+                <li class="nav-item"><a class="nav-link" href="vaccinations.html">واکسیناسیون</a></li>
+                <li class="nav-item"><a class="nav-link" href="vaccines.html">واکسن‌ها</a></li>
+                <li class="nav-item"><a class="nav-link" href="treatments.html">درمان‌ها</a></li>
             </ul>
         </div>
     </div>
@@ -33,12 +35,15 @@
     <table class="table table-bordered table-hover" id="sheepTable">
         <thead class="table-light">
             <tr>
-                <th>نام</th>
-                <th>سن</th>
+                <th>گوش1</th>
+                <th>گوش2</th>
+                <th>گوش3</th>
+                <th>سن (سال/ماه)</th>
                 <th>جنس</th>
-                <th>کد گوش</th>
-                <th>وضعیت</th>
-                <th>عملیات</th>
+                <th>وضعیت تولیدمثل</th>
+                <th>وضعیت سلامت</th>
+                <th>نژاد</th>
+                <th>جزئیات</th>
             </tr>
         </thead>
         <tbody>
@@ -57,10 +62,6 @@
       <div class="modal-body">
         <form id="sheepForm">
           <div class="mb-3">
-            <label class="form-label">نام</label>
-            <input type="text" class="form-control" id="sheepName" required>
-          </div>
-          <div class="mb-3">
             <label class="form-label">جنسیت</label>
             <select id="sheepGender" class="form-select">
               <option value="male">نر</option>
@@ -72,8 +73,20 @@
             <input type="date" class="form-control" id="sheepDob" required>
           </div>
           <div class="mb-3">
-            <label class="form-label">کد گوش</label>
-            <input type="text" class="form-control" id="sheepTag" required>
+            <label class="form-label">گوش 1</label>
+            <input type="text" class="form-control" id="ear1" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">گوش 2</label>
+            <input type="text" class="form-control" id="ear2">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">گوش 3</label>
+            <input type="text" class="form-control" id="ear3">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">نژاد</label>
+            <input type="text" class="form-control" id="gen">
           </div>
         </form>
       </div>
@@ -84,7 +97,98 @@
     </div>
   </div>
 </div>
+<!-- Detail Modal -->
+<div class="modal fade" id="detailModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">اطلاعات گوسفند</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div id="sheepDetails" class="mb-3"></div>
+        <form id="stateForm" class="row g-2 mb-3">
+          <div class="col">
+            <label class="form-label">وضعیت تولیدمثل</label>
+            <select id="stateReproduction" class="form-select">
+              <option value="normal">عادی</option>
+              <option value="pregnant">آبستن</option>
+              <option value="post_birth">پس از زایمان</option>
+            </select>
+          </div>
+          <div class="col">
+            <label class="form-label">وضعیت سلامت</label>
+            <select id="stateHealth" class="form-select">
+              <option value="healthy">سالم</option>
+              <option value="sick">بیمار</option>
+              <option value="under_treatment">درمان شده</option>
+            </select>
+          </div>
+          <div class="col-auto align-self-end">
+            <button type="submit" class="btn btn-primary">ذخیره وضعیت</button>
+          </div>
+        </form>
+        <hr>
+        <h6>درمان</h6>
+        <ul id="treatList" class="mb-2"></ul>
+        <form id="treatmentForm" class="row g-2 mb-3">
+          <div class="col">
+            <input type="text" id="diseaseDesc" class="form-control" placeholder="بیماری">
+          </div>
+          <div class="col">
+            <input type="text" id="treatDesc" class="form-control" placeholder="توضیح">
+          </div>
+          <div class="col">
+            <input type="date" id="treatDate" class="form-control">
+          </div>
+          <div class="col-auto">
+            <button type="submit" class="btn btn-success">افزودن</button>
+          </div>
+        </form>
+        <h6>واکسیناسیون</h6>
+        <ul id="vaccList" class="mb-2"></ul>
+        <form id="vaccForm" class="row g-2 mb-3">
+          <div class="col">
+            <select id="detailVaccine" class="form-select"></select>
+          </div>
+          <div class="col">
+            <input type="text" id="detailVaccinator" class="form-control" placeholder="واکسیناتور">
+          </div>
+          <div class="col">
+            <input type="date" id="detailVDate" class="form-control">
+          </div>
+          <div class="col">
+            <input type="text" id="detailVDesc" class="form-control" placeholder="توضیح">
+          </div>
+          <div class="col-auto">
+            <button type="submit" class="btn btn-success">افزودن</button>
+          </div>
+        </form>
+        <h6>زایش</h6>
+        <ul id="lambList" class="mb-2"></ul>
+        <form id="lambForm" class="row g-2">
+          <div class="col">
+            <input type="date" id="lambDate" class="form-control">
+          </div>
+          <div class="col">
+            <input type="number" id="lambMale" class="form-control" placeholder="نر">
+          </div>
+          <div class="col">
+            <input type="number" id="lambFemale" class="form-control" placeholder="ماده">
+          </div>
+          <div class="col">
+            <input type="number" id="lambDead" class="form-control" placeholder="مرده">
+          </div>
+          <div class="col-auto">
+            <button type="submit" class="btn btn-success">افزودن</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jalaali-js@1.1.0/index.min.js"></script>
 <script src="main.js"></script>
 <script src="sheep.js"></script>
 </body>

--- a/front/sheep.js
+++ b/front/sheep.js
@@ -7,6 +7,13 @@ const headersSheep = { 'Authorization': `Bearer ${tokenSheep}`, 'Content-Type': 
 const tableBody = document.querySelector('#sheepTable tbody');
 const form = document.getElementById('sheepForm');
 let editingId = null;
+let currentSheep = null;
+
+function toGregorianStr(jdate) {
+    const [jy,jm,jd] = jdate.split('-').map(Number);
+    const g = jalaali.toGregorian(jy,jm,jd);
+    return `${g.gy}-${String(g.gm).padStart(2,'0')}-${String(g.gd).padStart(2,'0')}`;
+}
 
 function loadSheep() {
     fetch(`${API_BASE}/sheep`, { headers: headersSheep })
@@ -15,17 +22,20 @@ function loadSheep() {
             tableBody.innerHTML = '';
             list.forEach(s => {
                 const tr = document.createElement('tr');
-                const age = new Date().getFullYear() - new Date(s.dateOfBirth).getFullYear();
+                const diffMs = Date.now() - new Date(s.dateOfBirth).getTime();
+                const years = Math.floor(diffMs / (365*24*60*60*1000));
+                const months = Math.floor((diffMs % (365*24*60*60*1000)) / (30*24*60*60*1000));
+                const age = `${years} سال ${months} ماه`;
                 tr.innerHTML = `
-                    <td>${s.name}</td>
+                    <td>${s.earNumber1}</td>
+                    <td>${s.earNumber2 || ''}</td>
+                    <td>${s.earNumber3 || ''}</td>
                     <td>${age}</td>
                     <td>${s.gender === 'male' ? 'نر' : 'ماده'}</td>
-                    <td>${s.id}</td>
-                    <td>${s.breedingDate ? 'آبستن' : '-'}</td>
-                    <td>
-                        <button class="btn btn-sm btn-primary me-1" onclick="editSheep('${s.id}')"><i class="bi bi-pencil"></i></button>
-                        <button class="btn btn-sm btn-danger" onclick="deleteSheep('${s.id}')"><i class="bi bi-trash"></i></button>
-                    </td>`;
+                    <td>${s.reproductionState}</td>
+                    <td>${s.healthState}</td>
+                    <td>${s.fatherGen || ''}</td>
+                    <td><button class="btn btn-sm btn-info" onclick="showSheep('${s.id}')">مشاهده</button></td>`;
                 tableBody.appendChild(tr);
             });
         });
@@ -36,10 +46,12 @@ window.editSheep = function(id) {
         .then(res => res.json())
         .then(s => {
             editingId = id;
-            document.getElementById('sheepName').value = s.name;
             document.getElementById('sheepGender').value = s.gender;
             document.getElementById('sheepDob').value = s.dateOfBirth.split('T')[0];
-            document.getElementById('sheepTag').value = s.id;
+            document.getElementById('ear1').value = s.earNumber1;
+            document.getElementById('ear2').value = s.earNumber2 || '';
+            document.getElementById('ear3').value = s.earNumber3 || '';
+            document.getElementById('gen').value = s.fatherGen || '';
             new bootstrap.Modal(document.getElementById('sheepModal')).show();
         });
 }
@@ -50,12 +62,147 @@ window.deleteSheep = function(id) {
         .then(() => loadSheep());
 }
 
+window.showSheep = function(id) {
+    fetch(`${API_BASE}/sheep/${id}`, { headers: headersSheep })
+        .then(res => res.json())
+        .then(s => {
+            currentSheep = s;
+            const detail = document.getElementById('sheepDetails');
+            detail.innerHTML = `
+                <img src="${s.photoUrl || 'https://cdn.jsdelivr.net/gh/twitter/twemoji/assets/svg/1f411.svg'}" class="img-thumbnail mb-3" style="max-width:150px">
+                <div>گوش 1: ${s.earNumber1}</div>
+                <div>گوش 2: ${s.earNumber2 || ''}</div>
+                <div>گوش 3: ${s.earNumber3 || ''}</div>
+                <div>شماره پلاک: ${s.neckNumber || ''}</div>
+                <div>تاریخ تولد: ${s.dateOfBirth.split('T')[0]}</div>
+                <div>وزن تولد: ${s.birthWeight}</div>
+                <div>نژاد: ${s.fatherGen}</div>`;
+            document.getElementById('stateReproduction').value = s.reproductionState;
+            document.getElementById('stateHealth').value = s.healthState;
+            fetch(`${API_BASE}/vaccines`, { headers: headersSheep })
+                .then(r => r.json())
+                .then(vlist => {
+                    const select = document.getElementById('detailVaccine');
+                    select.innerHTML = '';
+                    vlist.forEach(v => {
+                        const opt = document.createElement('option');
+                        opt.value = v.id;
+                        opt.textContent = v.name;
+                        select.appendChild(opt);
+                    });
+                    const vaccList = document.getElementById('vaccList');
+                    vaccList.innerHTML = '';
+                    (s.vaccinations || []).forEach(v => {
+                        const li = document.createElement('li');
+                        li.textContent = `${v.vaccine} - ${v.date.split('T')[0]}`;
+                        vaccList.appendChild(li);
+                    });
+                    const treatList = document.getElementById('treatList');
+                    treatList.innerHTML = '';
+                    (s.treatments || []).forEach(t => {
+                        const li = document.createElement('li');
+                        li.textContent = `${t.diseaseDescription} - ${t.date.split('T')[0]}`;
+                        treatList.appendChild(li);
+                    });
+                    const lambList = document.getElementById('lambList');
+                    lambList.innerHTML = '';
+                    (s.lambings || []).forEach(l => {
+                        const li = document.createElement('li');
+                        li.textContent = `${l.date.split('T')[0]} - ${l.numBorn}`;
+                        lambList.appendChild(li);
+                    });
+                    bootstrap.Modal.getOrCreateInstance(document.getElementById('detailModal')).show();
+                });
+        });
+}
+
+document.getElementById('stateForm').addEventListener('submit', e => {
+    e.preventDefault();
+    if (!currentSheep) return;
+    fetch(`${API_BASE}/sheep/${currentSheep.id}`, {
+        method: 'PUT',
+        headers: headersSheep,
+        body: JSON.stringify({
+            reproductionState: document.getElementById('stateReproduction').value,
+            healthState: document.getElementById('stateHealth').value
+        })
+    }).then(() => {
+        bootstrap.Modal.getInstance(document.getElementById('detailModal')).hide();
+        loadSheep();
+    });
+});
+
+document.getElementById('treatmentForm').addEventListener('submit', e => {
+    e.preventDefault();
+    if (!currentSheep) return;
+    const body = JSON.stringify({
+        diseaseDescription: document.getElementById('diseaseDesc').value,
+        treatDescription: document.getElementById('treatDesc').value,
+        date: toGregorianStr(document.getElementById('treatDate').value)
+    });
+    fetch(`${API_BASE}/sheep/${currentSheep.id}/treatments`, {
+        method: 'POST',
+        headers: headersSheep,
+        body
+    }).then(() => {
+        bootstrap.Modal.getInstance(document.getElementById('detailModal')).hide();
+        loadSheep();
+    });
+});
+
+document.getElementById('vaccForm').addEventListener('submit', e => {
+    e.preventDefault();
+    if (!currentSheep) return;
+    const body = JSON.stringify({
+        vaccine: document.getElementById('detailVaccine').value,
+        vaccinator: document.getElementById('detailVaccinator').value,
+        description: document.getElementById('detailVDesc').value,
+        date: toGregorianStr(document.getElementById('detailVDate').value)
+    });
+    fetch(`${API_BASE}/sheep/${currentSheep.id}/vaccinations`, {
+        method: 'POST',
+        headers: headersSheep,
+        body
+    }).then(() => {
+        bootstrap.Modal.getInstance(document.getElementById('detailModal')).hide();
+        loadSheep();
+    });
+});
+
+document.getElementById('lambForm').addEventListener('submit', e => {
+    e.preventDefault();
+    if (!currentSheep) return;
+    const males = parseInt(document.getElementById('lambMale').value,10)||0;
+    const females = parseInt(document.getElementById('lambFemale').value,10)||0;
+    const numDead = parseInt(document.getElementById('lambDead').value,10)||0;
+    const sexes = [];
+    for(let i=0;i<males;i++) sexes.push('male');
+    for(let i=0;i<females;i++) sexes.push('female');
+    const body = JSON.stringify({
+        date: toGregorianStr(document.getElementById('lambDate').value),
+        numBorn: males + females,
+        sexes,
+        numDead
+    });
+    fetch(`${API_BASE}/sheep/${currentSheep.id}/lambings`, {
+        method: 'POST',
+        headers: headersSheep,
+        body
+    }).then(() => {
+        bootstrap.Modal.getInstance(document.getElementById('detailModal')).hide();
+        loadSheep();
+    });
+});
+
 form.addEventListener('submit', e => {
     e.preventDefault();
     const body = JSON.stringify({
-        name: document.getElementById('sheepName').value,
         gender: document.getElementById('sheepGender').value,
-        dateOfBirth: document.getElementById('sheepDob').value
+        dateOfBirth: document.getElementById('sheepDob').value,
+        earNumber1: document.getElementById('ear1').value,
+        earNumber2: document.getElementById('ear2').value,
+        earNumber3: document.getElementById('ear3').value,
+        fatherGen: document.getElementById('gen').value
     });
     const method = editingId ? 'PUT' : 'POST';
     const url = editingId ? `${API_BASE}/sheep/${editingId}` : `${API_BASE}/sheep`;

--- a/front/treatments.html
+++ b/front/treatments.html
@@ -3,16 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>داشبورد - هلشتاین</title>
+    <title>درمان ها</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
 </head>
 <body class="bg-light">
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
     <div class="container-fluid">
-        <a class="navbar-brand" href="#">هلشتاین</a>
+        <a class="navbar-brand" href="dashboard.html">هلشتاین</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
@@ -22,22 +21,28 @@
                 <li class="nav-item"><a class="nav-link" href="sheep.html">گوسفندها</a></li>
                 <li class="nav-item"><a class="nav-link" href="vaccinations.html">واکسیناسیون</a></li>
                 <li class="nav-item"><a class="nav-link" href="vaccines.html">واکسن‌ها</a></li>
-                <li class="nav-item"><a class="nav-link" href="treatments.html">درمان‌ها</a></li>
+                <li class="nav-item"><a class="nav-link active" href="treatments.html">درمان‌ها</a></li>
             </ul>
         </div>
     </div>
 </nav>
 <main class="container pt-5 mt-4">
-    <div class="row g-3" id="statsCards">
-        <!-- Stats will be inserted here -->
-    </div>
-    <h2 class="mt-4">یادآورها</h2>
-    <div id="reminders" class="mt-3">
-        <!-- Reminder cards -->
-    </div>
+    <h2 class="mb-3">سوابق درمان</h2>
+    <table class="table table-bordered table-hover" id="treatTable">
+        <thead class="table-light">
+            <tr>
+                <th>گوسفند</th>
+                <th>بیماری</th>
+                <th>توضیح درمان</th>
+                <th>تاریخ</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
 </main>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jalaali-js@1.1.0/index.min.js"></script>
 <script src="main.js"></script>
-<script src="dashboard.js"></script>
+<script src="treatments.js"></script>
 </body>
 </html>

--- a/front/treatments.js
+++ b/front/treatments.js
@@ -1,0 +1,24 @@
+const tokenTr = localStorage.getItem('token');
+if (!tokenTr) {
+    window.location.href = 'index.html';
+}
+const headersTr = { 'Authorization': `Bearer ${tokenTr}`, 'Content-Type': 'application/json' };
+
+const tableTr = document.querySelector('#treatTable tbody');
+
+function loadTreatments() {
+    fetch(`${API_BASE}/sheep`, { headers: headersTr })
+        .then(res => res.json())
+        .then(list => {
+            tableTr.innerHTML = '';
+            list.forEach(s => {
+                (s.treatments || []).forEach(t => {
+                    const tr = document.createElement('tr');
+                    tr.innerHTML = `<td>${s.earNumber1}</td><td>${t.diseaseDescription}</td><td>${t.treatDescription}</td><td>${t.date ? t.date.split('T')[0] : ''}</td>`;
+                    tableTr.appendChild(tr);
+                });
+            });
+        });
+}
+
+loadTreatments();

--- a/front/vaccinations.html
+++ b/front/vaccinations.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>واکسیناسیون</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="dashboard.html">هلشتاین</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav ms-auto">
+                <li class="nav-item"><a class="nav-link" href="dashboard.html">داشبورد</a></li>
+                <li class="nav-item"><a class="nav-link" href="sheep.html">گوسفندها</a></li>
+                <li class="nav-item"><a class="nav-link active" href="vaccinations.html">واکسیناسیون</a></li>
+                <li class="nav-item"><a class="nav-link" href="vaccines.html">واکسن‌ها</a></li>
+                <li class="nav-item"><a class="nav-link" href="treatments.html">درمان‌ها</a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+<main class="container pt-5 mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="m-0">سوابق واکسن</h2>
+        <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#vaccineModal"><i class="bi bi-plus-circle"></i> افزودن</button>
+    </div>
+    <table class="table table-bordered table-hover" id="vaccineTable">
+        <thead class="table-light">
+            <tr>
+                <th>گوسفند</th>
+                <th>واکسن</th>
+                <th>تاریخ</th>
+                <th>واکسیناتور</th>
+                <th>توضیح</th>
+            </tr>
+        </thead>
+        <tbody>
+            <!-- Rows inserted here -->
+        </tbody>
+    </table>
+</main>
+<div class="modal fade" id="vaccineModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">افزودن واکسن</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="vaccineForm">
+          <div class="mb-3">
+            <label class="form-label">گوسفند</label>
+            <select id="vaccineSheep" class="form-select"></select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">نام واکسن</label>
+            <select id="vaccineName" class="form-select"></select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">تاریخ</label>
+            <input type="date" class="form-control" id="vaccineDate" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">واکسیناتور</label>
+            <input type="text" class="form-control" id="vaccineVaccinator" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">توضیح</label>
+            <textarea class="form-control" id="vaccineDesc"></textarea>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">انصراف</button>
+        <button type="submit" form="vaccineForm" class="btn btn-primary">ذخیره</button>
+      </div>
+    </div>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jalaali-js@1.1.0/index.min.js"></script>
+<script src="main.js"></script>
+<script src="vaccinations.js"></script>
+</body>
+</html>

--- a/front/vaccinations.js
+++ b/front/vaccinations.js
@@ -1,0 +1,79 @@
+const tokenVacc = localStorage.getItem('token');
+if (!tokenVacc) {
+    window.location.href = 'index.html';
+}
+const headersVacc = { 'Authorization': `Bearer ${tokenVacc}`, 'Content-Type': 'application/json' };
+
+const tableVacc = document.querySelector('#vaccineTable tbody');
+const formVacc = document.getElementById('vaccineForm');
+const sheepSelect = document.getElementById('vaccineSheep');
+const vaccineSelect = document.getElementById('vaccineName');
+
+function toGregorianStr(jdate) {
+    const [jy, jm, jd] = jdate.split('-').map(Number);
+    const g = jalaali.toGregorian(jy, jm, jd);
+    return `${g.gy}-${String(g.gm).padStart(2,'0')}-${String(g.gd).padStart(2,'0')}`;
+}
+
+function loadVaccinations() {
+    fetch(`${API_BASE}/sheep`, { headers: headersVacc })
+        .then(res => res.json())
+        .then(list => {
+            tableVacc.innerHTML = '';
+            sheepSelect.innerHTML = '';
+            list.forEach(s => {
+                const opt = document.createElement('option');
+                opt.value = s.id;
+                opt.textContent = s.earNumber1;
+                sheepSelect.appendChild(opt);
+                (s.vaccinations || []).forEach(v => {
+                    const tr = document.createElement('tr');
+                    tr.innerHTML = `<td>${s.earNumber1}</td><td>${v.vaccine}</td><td>${v.date ? v.date.split('T')[0] : ''}</td><td>${v.vaccinator}</td><td>${v.description || ''}</td>`;
+                    tableVacc.appendChild(tr);
+                });
+            });
+        });
+}
+
+function loadVaccineDefs() {
+    fetch(`${API_BASE}/vaccines`, { headers: headersVacc })
+        .then(res => res.json())
+        .then(list => {
+            vaccineSelect.innerHTML = '';
+            list.forEach(v => {
+                const opt = document.createElement('option');
+                opt.value = v.id;
+                opt.textContent = v.name;
+                vaccineSelect.appendChild(opt);
+            });
+        });
+}
+
+formVacc.addEventListener('submit', e => {
+    e.preventDefault();
+    const sheepID = sheepSelect.value;
+    fetch(`${API_BASE}/sheep/${sheepID}`, { headers: headersVacc })
+        .then(res => res.json())
+        .then(sheep => {
+            const vaccinations = sheep.vaccinations || [];
+            vaccinations.push({
+                vaccine: vaccineSelect.value,
+                vaccinator: document.getElementById('vaccineVaccinator').value,
+                description: document.getElementById('vaccineDesc').value,
+                date: toGregorianStr(document.getElementById('vaccineDate').value)
+            });
+            return fetch(`${API_BASE}/sheep/${sheepID}`, {
+                method: 'PUT',
+                headers: headersVacc,
+                body: JSON.stringify({ vaccinations })
+            });
+        })
+        .then(() => {
+            bootstrap.Modal.getInstance(document.getElementById('vaccineModal')).hide();
+            formVacc.reset();
+            loadVaccinations();
+        });
+});
+
+loadVaccineDefs();
+loadVaccinations();

--- a/front/vaccines.html
+++ b/front/vaccines.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>واکسن ها</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="dashboard.html">هلشتاین</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav ms-auto">
+                <li class="nav-item"><a class="nav-link" href="dashboard.html">داشبورد</a></li>
+                <li class="nav-item"><a class="nav-link" href="sheep.html">گوسفندها</a></li>
+                <li class="nav-item"><a class="nav-link" href="vaccinations.html">واکسیناسیون</a></li>
+                <li class="nav-item"><a class="nav-link active" href="vaccines.html">واکسن‌ها</a></li>
+                <li class="nav-item"><a class="nav-link" href="treatments.html">درمان‌ها</a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+<main class="container pt-5 mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="m-0">لیست واکسن‌ها</h2>
+        <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#vaccineDefModal"><i class="bi bi-plus-circle"></i> افزودن</button>
+    </div>
+    <table class="table table-bordered table-hover" id="vaccineDefTable">
+        <thead class="table-light">
+            <tr>
+                <th>نام</th>
+                <th>دوره (ماه)</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</main>
+<div class="modal fade" id="vaccineDefModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">افزودن واکسن</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="vaccineDefForm">
+          <div class="mb-3">
+            <label class="form-label">نام واکسن</label>
+            <input type="text" class="form-control" id="defName" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">دوره (ماه)</label>
+            <input type="number" class="form-control" id="defInterval" required>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">انصراف</button>
+        <button type="submit" form="vaccineDefForm" class="btn btn-primary">ذخیره</button>
+      </div>
+    </div>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="main.js"></script>
+<script src="vaccines.js"></script>
+</body>
+</html>

--- a/front/vaccines.js
+++ b/front/vaccines.js
@@ -1,0 +1,37 @@
+const tokenVaxDef = localStorage.getItem('token');
+if (!tokenVaxDef) {
+    window.location.href = 'index.html';
+}
+const headersVaxDef = { 'Authorization': `Bearer ${tokenVaxDef}`, 'Content-Type': 'application/json' };
+
+const tableVaxDef = document.querySelector('#vaccineDefTable tbody');
+const formVaxDef = document.getElementById('vaccineDefForm');
+
+function loadVaccineDefs() {
+    fetch(`${API_BASE}/vaccines`, { headers: headersVaxDef })
+        .then(res => res.json())
+        .then(list => {
+            tableVaxDef.innerHTML = '';
+            list.forEach(v => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `<td>${v.name}</td><td>${v.intervalMonths}</td>`;
+                tableVaxDef.appendChild(tr);
+            });
+        });
+}
+
+formVaxDef.addEventListener('submit', e => {
+    e.preventDefault();
+    const body = JSON.stringify({
+        name: document.getElementById('defName').value,
+        intervalMonths: parseInt(document.getElementById('defInterval').value, 10)
+    });
+    fetch(`${API_BASE}/vaccines`, { method: 'POST', headers: headersVaxDef, body })
+        .then(() => {
+            bootstrap.Modal.getInstance(document.getElementById('vaccineDefModal')).hide();
+            formVaxDef.reset();
+            loadVaccineDefs();
+        });
+});
+
+loadVaccineDefs();

--- a/internal/application/services/sheep_service.go
+++ b/internal/application/services/sheep_service.go
@@ -81,3 +81,42 @@ func (s *SheepService) DeleteSheep(ctx context.Context, userID, sheepID string) 
 	// Add business rules specific to deleting
 	return s.repo.DeleteSheep(ctx, userID, sheepID)
 }
+
+// AddVaccination appends a vaccination record to the sheep.
+func (s *SheepService) AddVaccination(ctx context.Context, userID, sheepID string, v domain.Vaccination) error {
+	sh, err := s.repo.GetSheepByID(ctx, userID, sheepID)
+	if err != nil {
+		return err
+	}
+	if sh.OwnerUserID != userID {
+		return domain.ErrUnauthorized
+	}
+	sh.Vaccinations = append(sh.Vaccinations, v)
+	return s.repo.UpdateSheep(ctx, sh)
+}
+
+// AddTreatment appends a treatment record to the sheep.
+func (s *SheepService) AddTreatment(ctx context.Context, userID, sheepID string, t domain.Treatment) error {
+	sh, err := s.repo.GetSheepByID(ctx, userID, sheepID)
+	if err != nil {
+		return err
+	}
+	if sh.OwnerUserID != userID {
+		return domain.ErrUnauthorized
+	}
+	sh.Treatments = append(sh.Treatments, t)
+	return s.repo.UpdateSheep(ctx, sh)
+}
+
+// AddLambing appends a lambing record to the sheep.
+func (s *SheepService) AddLambing(ctx context.Context, userID, sheepID string, l domain.Lambing) error {
+	sh, err := s.repo.GetSheepByID(ctx, userID, sheepID)
+	if err != nil {
+		return err
+	}
+	if sh.OwnerUserID != userID {
+		return domain.ErrUnauthorized
+	}
+	sh.Lambings = append(sh.Lambings, l)
+	return s.repo.UpdateSheep(ctx, sh)
+}

--- a/internal/infrastructure/http/handlers/sheep_handler.go
+++ b/internal/infrastructure/http/handlers/sheep_handler.go
@@ -263,3 +263,107 @@ func (h *SheepHandler) DeleteSheep(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusNoContent) // 204 No Content
 }
+
+// AddVaccination handles POST /sheep/{id}/vaccinations requests.
+func (h *SheepHandler) AddVaccination(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	sheepID := vars["id"]
+
+	var req dto.VaccinationDTO
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, domain.ErrInvalidInput.Error(), http.StatusBadRequest)
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	err = h.sheepService.AddVaccination(r.Context(), userID, sheepID, domain.Vaccination{
+		Date:        time.Time(req.Date),
+		Vaccine:     req.Vaccine,
+		Vaccinator:  req.Vaccinator,
+		Description: req.Description,
+	})
+	if err != nil {
+		if err == domain.ErrNotFound {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+// AddTreatment handles POST /sheep/{id}/treatments requests.
+func (h *SheepHandler) AddTreatment(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	sheepID := vars["id"]
+
+	var req dto.TreatmentDTO
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, domain.ErrInvalidInput.Error(), http.StatusBadRequest)
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	err = h.sheepService.AddTreatment(r.Context(), userID, sheepID, domain.Treatment{
+		Date:               time.Time(req.Date),
+		DiseaseDescription: req.DiseaseDescription,
+		TreatDescription:   req.TreatDescription,
+	})
+	if err != nil {
+		if err == domain.ErrNotFound {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+// AddLambing handles POST /sheep/{id}/lambings requests.
+func (h *SheepHandler) AddLambing(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	sheepID := vars["id"]
+
+	var req dto.LambingDTO
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, domain.ErrInvalidInput.Error(), http.StatusBadRequest)
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	err = h.sheepService.AddLambing(r.Context(), userID, sheepID, domain.Lambing{
+		Date:    time.Time(req.Date),
+		NumBorn: req.NumBorn,
+		Sexes:   req.Sexes,
+		NumDead: req.NumDead,
+	})
+	if err != nil {
+		if err == domain.ErrNotFound {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}

--- a/internal/infrastructure/http/router.go
+++ b/internal/infrastructure/http/router.go
@@ -74,6 +74,9 @@ func (s *Server) setupRoutes() {
 	protectedRouter.HandleFunc("/sheep/{id}", s.SheepHandler.GetSheepByID).Methods("GET")
 	protectedRouter.HandleFunc("/sheep/{id}", s.SheepHandler.UpdateSheep).Methods("PUT")
 	protectedRouter.HandleFunc("/sheep/{id}", s.SheepHandler.DeleteSheep).Methods("DELETE")
+	protectedRouter.HandleFunc("/sheep/{id}/vaccinations", s.SheepHandler.AddVaccination).Methods("POST")
+	protectedRouter.HandleFunc("/sheep/{id}/treatments", s.SheepHandler.AddTreatment).Methods("POST")
+	protectedRouter.HandleFunc("/sheep/{id}/lambings", s.SheepHandler.AddLambing).Methods("POST")
 
 	// Reminder Route
 	protectedRouter.HandleFunc("/reminders", s.ReminderHandler.GetReminders).Methods("GET")


### PR DESCRIPTION
## Summary
- extend sheep service for vaccination/treatment/lambing
- expose new POST routes in router
- update sheep page to show history and post new records
- adapt sheep creation form to match backend fields
- display age in years/months format

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_687129383ee48322ab40b3b7ff4a5e0d