### PR TITLE
Add Docker setup and GitHub CI workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+go.mod
+go.sum
+*.md
+.git
+front

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+      - name: Build
+        run: go build ./cmd/api
+      - name: Run vet
+        run: go vet ./...
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: sheep-farm:ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Build stage
+FROM golang:1.21 AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o sheep-farm ./cmd/api
+
+# Runtime stage
+FROM gcr.io/distroless/base-debian11
+WORKDIR /app
+COPY --from=builder /app/sheep-farm ./sheep-farm
+EXPOSE 8080
+CMD ["./sheep-farm"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Sheep Farming Backend
+
+This repository contains a Go backend for managing sheep farming operations. The project includes a small JavaScript front-end under the `front/` directory.
+
+## Docker
+
+A `Dockerfile` is provided for building a production container. Build and run the container with:
+
+```bash
+docker build -t sheep-farm .
+docker run -p 8080:8080 sheep-farm
+```
+
+Environment variables such as `FIREBASE_CREDENTIALS_PATH` should be provided when running the container.
+
+## CI/CD
+
+Continuous integration is configured via GitHub Actions in `.github/workflows/ci.yml`. The workflow performs the following on each push or pull request:
+
+- Checks out the code.
+- Sets up Go 1.23.
+- Builds the application and runs `go vet`.
+- Builds the Docker image to ensure the container configuration is valid.
+


### PR DESCRIPTION
## Summary
- containerize the Go API with a new `Dockerfile`
- ignore build artifacts with `.dockerignore`
- add a workflow `ci.yml` for building and vetting the app and verifying the Docker build
- document the new Docker and CI/CD setup in a `README`

## Testing
- `go vet ./...`
- `go build ./cmd/api`
- `docker build -t sheep-farm-test .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717de94be88322acc04d5699bc381b