### PR TITLE
Add frontend Docker support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,12 @@ services:
       - ./.env
     image: ghcr.io/rohamizadidoost/sheep-farming
     restart: unless-stopped
+  front:
+    build:
+      context: ./front
+      dockerfile: Dockerfile
+    ports:
+      - "80:80"
+    container_name: Frontend
+    image: ghcr.io/rohamizadidoost/sheep-farming-front
+    restart: unless-stopped

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY . /usr/share/nginx/html


### PR DESCRIPTION
## Summary
- add Dockerfile for frontend using nginx
- extend docker-compose configuration with `front` service

## Testing
- `go vet ./...`
- `go fmt ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6871a31b925483228c0c48263fd1e426