### PR TITLE
Add run modes and adjustable ports

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -87,7 +87,11 @@ func main() {
 	}
 
 	appScheduler := scheduler.NewScheduler(reminderService, fixedUserIDForScheduler)
-	appScheduler.StartScheduler() // Start the scheduler in a goroutine
+
+	runMode := os.Getenv("RUN_MODE")
+	if runMode == "server" {
+		appScheduler.StartScheduler() // Start scheduler only on server
+	}
 
 	// --- 6. Initialize and Start HTTP Server (Presentation Layer) ---
 	// User ID for handlers will now come from context after authentication.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - ENV=production
+      - RUN_MODE=server
+      - FRONTEND_ORIGIN=http://82.115.17.206:5500
     container_name: Backend
     env_file:
       - ./.env

--- a/front/main.js
+++ b/front/main.js
@@ -1,10 +1,10 @@
 const statusEl = document.getElementById('status');
 const loginForm = document.getElementById('loginForm');
 const loginMessage = document.getElementById('loginMessage');
-const API_BASE = 'http://82.115.17.206:8080/api/v1';
+const API_BASE = location.hostname === 'localhost' ? 'http://localhost:8080/api/v1' : 'http://82.115.17.206:8080/api/v1';
 
 // Check connection to backend
-fetch('http://82.115.17.206:8080/')
+fetch(API_BASE.replace('/api/v1','/'))
   .then(res => {
     if (res.ok) {
       statusEl.textContent = 'ارتباط با سرور برقرار است';

--- a/internal/application/ports/reminder_service.go
+++ b/internal/application/ports/reminder_service.go
@@ -1,0 +1,11 @@
+package ports
+
+import (
+	"context"
+	"sheep_farm_backend_go/internal/domain"
+)
+
+// ReminderService defines reminder related operations.
+type ReminderService interface {
+	CalculateAndSendReminders(ctx context.Context, userID string) ([]domain.Reminder, error)
+}

--- a/internal/infrastructure/http/router.go
+++ b/internal/infrastructure/http/router.go
@@ -3,6 +3,7 @@ package http
 import (
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -105,12 +106,17 @@ func (s *Server) setupRoutes() {
 // Start runs the HTTP server.
 func (s *Server) Start(addr string) {
 	// Configure CORS
+	allowedOrigin := os.Getenv("FRONTEND_ORIGIN")
+	if allowedOrigin == "" {
+		allowedOrigin = "http://localhost:5500"
+	}
+
 	c := cors.New(cors.Options{
-		AllowedOrigins:   []string{"http://localhost:3000", "http://[::]:5500", "http://82.115.17.206:5500"}, // Allow your React app
+		AllowedOrigins:   []string{allowedOrigin},
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Content-Type", "Authorization"}, // Authorization header is now important!
+		AllowedHeaders:   []string{"Content-Type", "Authorization"},
 		AllowCredentials: true,
-		Debug:            false, // Set to true for debugging CORS issues
+		Debug:            false,
 	})
 
 	handler := c.Handler(s.Router)

--- a/internal/infrastructure/scheduler/cron_scheduler.go
+++ b/internal/infrastructure/scheduler/cron_scheduler.go
@@ -7,20 +7,20 @@ import (
 
 	"github.com/robfig/cron/v3" // Popular Go scheduler library
 
-	"sheep_farm_backend_go/internal/application/services" // ReminderService
+	"sheep_farm_backend_go/internal/application/ports" // ReminderService port
 )
 
 // Scheduler manages periodic tasks like sending reminders.
 type Scheduler struct {
 	cron            *cron.Cron
-	reminderService *services.ReminderService
+	reminderService ports.ReminderService
 	// In a real app, you might have an authentication service to get user IDs
 	// Or iterate over all users in your database.
 	fixedUserID string // For simplicity, we'll use a fixed user ID for scheduling reminders
 }
 
 // NewScheduler creates a new Scheduler instance.
-func NewScheduler(reminderService *services.ReminderService, fixedUserID string) *Scheduler {
+func NewScheduler(reminderService ports.ReminderService, fixedUserID string) *Scheduler {
 	return &Scheduler{
 		cron:            cron.New(), // cron.New(cron.WithChain(cron.Recover(log.New(os.Stdout, "", log.LstdFlags)))), for robust error handling
 		reminderService: reminderService,


### PR DESCRIPTION
## Summary
- add reminder service port and use it in scheduler
- load allowed frontend origin from env
- run scheduler only when `RUN_MODE=server`
- configure compose file for server run mode
- set frontend to auto-use local API when hosted locally

## Testing
- `go build -v ./cmd/api`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6874c4ebc19c8322aeb92d8a88f6f641