### PR TITLE
Add Jalali date picker and lambing page

### DIFF
--- a/front-react/package-lock.json
+++ b/front-react/package-lock.json
@@ -12,6 +12,7 @@
         "moment-jalaali": "^0.10.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-modern-calendar-datepicker": "^3.1.6",
         "react-router-dom": "^6.16.0",
         "react-scripts": "^5.0.1"
       }
@@ -13825,6 +13826,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
+    },
+    "node_modules/react-modern-calendar-datepicker": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/react-modern-calendar-datepicker/-/react-modern-calendar-datepicker-3.1.6.tgz",
+      "integrity": "sha512-lnMqEMj9Wn32/sm119tjCl5lOkq4u9vJE7wggi7hdXV4s8rPdKlH56FVVehlBi0dfYeWQVZ9npY384Zprjn4WA==",
+      "license": "MIT",
+      "dependencies": {
+        "jalaali-js": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",

--- a/front-react/package.json
+++ b/front-react/package.json
@@ -7,6 +7,7 @@
     "moment-jalaali": "^0.10.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-modern-calendar-datepicker": "^3.1.6",
     "react-router-dom": "^6.16.0",
     "react-scripts": "^5.0.1"
   },

--- a/front-react/src/App.js
+++ b/front-react/src/App.js
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import LoginPage from './pages/LoginPage';
 import DashboardPage from './pages/DashboardPage';
 import SheepPage from './pages/SheepPage';
+import LambingsPage from './pages/LambingsPage';
 import VaccinationsPage from './pages/VaccinationsPage';
 import VaccinesPage from './pages/VaccinesPage';
 import TreatmentsPage from './pages/TreatmentsPage';
@@ -16,6 +17,7 @@ export default function App() {
         <Route path="/" element={token ? <Navigate to="/dashboard" /> : <LoginPage />} />
         <Route path="/dashboard" element={<DashboardPage />} />
         <Route path="/sheep" element={<SheepPage />} />
+        <Route path="/lambings" element={<LambingsPage />} />
         <Route path="/vaccinations" element={<VaccinationsPage />} />
         <Route path="/vaccines" element={<VaccinesPage />} />
         <Route path="/treatments" element={<TreatmentsPage />} />

--- a/front-react/src/components/JalaliDatePicker.js
+++ b/front-react/src/components/JalaliDatePicker.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { DatePicker } from 'react-modern-calendar-datepicker';
+
+export default function JalaliDatePicker({ value, onChange }) {
+  // value is a string YYYY-MM-DD in Gregorian
+  const gregToJalali = dateStr => {
+    if (!dateStr) return null;
+    const [gy, gm, gd] = dateStr.split('-').map(Number);
+    const j = window.jalaali.toJalaali(gy, gm, gd);
+    return { year: j.jy, month: j.jm, day: j.jd };
+  };
+  const jalaliToGreg = dateObj => {
+    if (!dateObj) return '';
+    const g = window.jalaali.toGregorian(dateObj.year, dateObj.month, dateObj.day);
+    return `${g.gy}-${String(g.gm).padStart(2, '0')}-${String(g.gd).padStart(2, '0')}`;
+  };
+  const handleChange = d => onChange(jalaliToGreg(d));
+  return (
+    <DatePicker
+      value={gregToJalali(value)}
+      onChange={handleChange}
+      locale="fa"
+      inputPlaceholder="انتخاب تاریخ"
+      shouldHighlightWeekends
+    />
+  );
+}

--- a/front-react/src/components/NavBar.js
+++ b/front-react/src/components/NavBar.js
@@ -16,6 +16,7 @@ export default function NavBar() {
             <li className="nav-item"><Link className="nav-link" to="/vaccinations">واکسیناسیون</Link></li>
             <li className="nav-item"><Link className="nav-link" to="/vaccines">واکسن‌ها</Link></li>
             <li className="nav-item"><Link className="nav-link" to="/treatments">درمان‌ها</Link></li>
+            <li className="nav-item"><Link className="nav-link" to="/lambings">زایش‌ها</Link></li>
           </ul>
         </div>
       </div>

--- a/front-react/src/index.css
+++ b/front-react/src/index.css
@@ -5,3 +5,14 @@ body {
   direction: rtl;
   text-align: right;
 }
+
+.login-background {
+  background-image: url('https://source.unsplash.com/featured/?sheep');
+  background-size: cover;
+  background-position: center;
+}
+
+.login-card {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 12px;
+}

--- a/front-react/src/index.js
+++ b/front-react/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import 'bootstrap/dist/css/bootstrap.min.css';
+import 'react-modern-calendar-datepicker/lib/DatePicker.css';
 import './index.css';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));

--- a/front-react/src/pages/LambingsPage.js
+++ b/front-react/src/pages/LambingsPage.js
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import NavBar from '../components/NavBar';
+import { apiFetch } from '../utils/api';
+import JalaliDatePicker from '../components/JalaliDatePicker';
+import { toJalali } from '../utils/jdate';
+
+export default function LambingsPage() {
+  const [list, setList] = useState([]);
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+
+  const load = () => {
+    const params = new URLSearchParams();
+    if (from) params.append('from', from);
+    if (to) params.append('to', to);
+    const qs = params.toString() ? `?${params.toString()}` : '';
+    apiFetch(`/lambings${qs}`)
+      .then(res => res.json())
+      .then(setList);
+  };
+
+  useEffect(() => { load(); }, []);
+
+  return (
+    <>
+      <NavBar />
+      <main className="container pt-5 mt-4">
+        <div className="mb-3">
+          <form onSubmit={e=>{e.preventDefault();load();}} className="row g-2">
+            <div className="col-md-4">
+              <JalaliDatePicker value={from} onChange={setFrom} />
+            </div>
+            <div className="col-md-4">
+              <JalaliDatePicker value={to} onChange={setTo} />
+            </div>
+            <div className="col-md-4">
+              <button className="btn btn-primary w-100" type="submit">فیلتر</button>
+            </div>
+          </form>
+        </div>
+        <table className="table table-bordered" id="lambTable">
+          <thead className="table-light">
+            <tr>
+              <th>گوسفند</th>
+              <th>تاریخ</th>
+              <th>تعداد تولد</th>
+              <th>جنسیت‌ها</th>
+              <th>تلفات</th>
+            </tr>
+          </thead>
+          <tbody>
+            {list.map((l,i) => (
+              <tr key={i}>
+                <td>{l.sheepEar || ''}</td>
+                <td>{toJalali(l.date)}</td>
+                <td>{l.numBorn}</td>
+                <td>نر:{l.numMaleBorn} ماده:{l.numFemaleBorn}</td>
+                <td>{l.numDead}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </main>
+    </>
+  );
+}

--- a/front-react/src/pages/LoginPage.js
+++ b/front-react/src/pages/LoginPage.js
@@ -21,8 +21,8 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="container d-flex align-items-center justify-content-center vh-100">
-      <form onSubmit={submit} className="card p-4 shadow" style={{minWidth: '320px'}}>
+    <div className="login-background d-flex align-items-center justify-content-center vh-100">
+      <form onSubmit={submit} className="login-card p-4 shadow" style={{minWidth: '320px'}}>
         <h4 className="mb-3 text-center">ورود</h4>
         <input className="form-control mb-2" placeholder="ایمیل" value={email} onChange={e => setEmail(e.target.value)} />
         <input type="password" className="form-control mb-2" placeholder="گذرواژه" value={password} onChange={e => setPassword(e.target.value)} />

--- a/front-react/src/pages/SheepPage.js
+++ b/front-react/src/pages/SheepPage.js
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import NavBar from '../components/NavBar';
+import JalaliDatePicker from '../components/JalaliDatePicker';
 import { apiFetch } from '../utils/api';
-import { toJalali, toGregorian } from '../utils/jdate';
+import { toJalali } from '../utils/jdate';
 
 export default function SheepPage() {
   const [list, setList] = useState([]);
@@ -28,7 +29,7 @@ export default function SheepPage() {
     e.preventDefault();
     const body = JSON.stringify({
       gender: form.gender,
-      dateOfBirth: toGregorian(form.dob),
+      dateOfBirth: form.dob,
       birthWeight: parseFloat(form.weight) || 0,
       earNumber1: form.ear1,
       earNumber2: form.ear2,
@@ -96,7 +97,7 @@ export default function SheepPage() {
           <h5 className="mb-3">{editingId ? 'ویرایش گوسفند' : 'افزودن گوسفند'}</h5>
           <div className="row g-2">
             <div className="col-md-4"><select className="form-select" value={form.gender} onChange={e=>setForm({...form,gender:e.target.value})}><option value="male">نر</option><option value="female">ماده</option></select></div>
-            <div className="col-md-4"><input type="date" className="form-control" value={form.dob} onChange={e=>setForm({...form,dob:e.target.value})} required /></div>
+              <div className="col-md-4"><JalaliDatePicker value={form.dob} onChange={d=>setForm({...form,dob:d})} /></div>
             <div className="col-md-4"><input type="number" step="0.1" className="form-control" value={form.weight} onChange={e=>setForm({...form,weight:e.target.value})} placeholder="وزن تولد" /></div>
             <div className="col-md-4"><input className="form-control" value={form.ear1} onChange={e=>setForm({...form,ear1:e.target.value})} placeholder="گوش 1" required/></div>
             <div className="col-md-4"><input className="form-control" value={form.ear2} onChange={e=>setForm({...form,ear2:e.target.value})} placeholder="گوش 2" /></div>

--- a/internal/infrastructure/persistence/postgres/sheep_repository.go
+++ b/internal/infrastructure/persistence/postgres/sheep_repository.go
@@ -57,7 +57,7 @@ func (r *SheepRepository) FilterSheep(ctx context.Context, userID uint, gender *
 			q = q.Where("date_of_birth >= ?", now.AddDate(0, 0, -*maxAgeDays))
 		}
 	}
-	err := q.Find(&list).Error
+	err := q.Preload("Lambings").Preload("Vaccinations").Preload("Treatments").Find(&list).Error
 	return list, err
 }
 


### PR DESCRIPTION
## Summary
- include `react-modern-calendar-datepicker` to support Jalali dates
- theme login page with a sheep background and card styling
- add a reusable `JalaliDatePicker` component
- use Jalali date picker on the sheep page and create a lambings page
- expose lambings link on navigation bar
- preload related data when filtering sheep

## Testing
- `npm test --prefix front-react`

------
https://chatgpt.com/codex/tasks/task_e_6888ac27a5fc83229e608c4c997a4045