### PR TITLE
Add CI workflow for Go backend and React frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  backend:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.x'
+
+      - name: Download Go dependencies
+        run: go mod download
+
+      - name: Run Go tests
+        run: go test ./...
+
+  frontend:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: front-react/package-lock.json
+
+      - name: Install dependencies
+        working-directory: front-react
+        run: npm ci
+
+      - name: Run frontend tests
+        working-directory: front-react
+        env:
+          CI: true
+        run: npm test -- --watch=false --passWithNoTests
+
+      - name: Build frontend
+        working-directory: front-react
+        env:
+          CI: true
+        run: npm run build


### PR DESCRIPTION
## Summary
- add a CI workflow to run Go module download and tests on pushes and pull requests to main
- add frontend CI steps that cache npm installs, run tests without watch, and build the React app

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d453121d883219d1c1aea5f8f8ba8)